### PR TITLE
make all dutch language metadata settings capital case

### DIFF
--- a/Assumptions/vufsw-assumptions-0265-nl/vufsw-assumptions-0265-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0265-nl/vufsw-assumptions-0265-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-assumptions-0266-nl/vufsw-assumptions-0266-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0266-nl/vufsw-assumptions-0266-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-assumptions-0280-nl/vufsw-assumptions-0280-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0280-nl/vufsw-assumptions-0280-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-assumptions-0286-nl/vufsw-assumptions-0286-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0286-nl/vufsw-assumptions-0286-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-assumptions-0331-nl/vufsw-assumptions-0331-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0331-nl/vufsw-assumptions-0331-nl.Rmd
@@ -32,6 +32,6 @@ exshuffle: TRUE
 exsection: Assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-homogeneityofvariance-0263-nl/vufsw-homogeneityofvariance-0263-nl.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0263-nl/vufsw-homogeneityofvariance-0263-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homogeneityofvariance-0309-nl/vufsw-homogeneityofvariance-0309-nl.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0309-nl/vufsw-homogeneityofvariance-0309-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homogeneityofvariance-0333-nl/vufsw-homogeneityofvariance-0333-nl.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0333-nl/vufsw-homogeneityofvariance-0333-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homoscedasticity-0278-nl/vufsw-homoscedasticity-0278-nl.Rmd
+++ b/Assumptions/vufsw-homoscedasticity-0278-nl/vufsw-homoscedasticity-0278-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: assumptions/homoscedasticity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homoscedasticity-2108-nl/vufsw-homoscedasticity-2108-nl.Rmd
+++ b/Assumptions/vufsw-homoscedasticity-2108-nl/vufsw-homoscedasticity-2108-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions/homoscedasticity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-levene's_test-1050-nl/vufsw-levene's_test-1050-nl.Rmd
+++ b/Assumptions/vufsw-levene's_test-1050-nl/vufsw-levene's_test-1050-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-levene's_test-1381-nl/vufsw-levene's_test-1381-nl.Rmd
+++ b/Assumptions/vufsw-levene's_test-1381-nl/vufsw-levene's_test-1381-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-levene'stest-0306-nl/vufsw-levene'stest-0306-nl.Rmd
+++ b/Assumptions/vufsw-levene'stest-0306-nl/vufsw-levene'stest-0306-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-levene'stest-0307-nl/vufsw-levene'stest-0307-nl.Rmd
+++ b/Assumptions/vufsw-levene'stest-0307-nl/vufsw-levene'stest-0307-nl.Rmd
@@ -42,6 +42,6 @@ extol: 0
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-levenestest-1288-nl/vufsw-levenestest-1288-nl.Rmd
+++ b/Assumptions/vufsw-levenestest-1288-nl/vufsw-levenestest-1288-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: interpreting output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-linearity-0279-nl/vufsw-linearity-0279-nl.Rmd
+++ b/Assumptions/vufsw-linearity-0279-nl/vufsw-linearity-0279-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: assumptions/linearity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-multicolinearity-2106-nl/vufsw-multicolinearity-2106-nl.Rmd
+++ b/Assumptions/vufsw-multicolinearity-2106-nl/vufsw-multicolinearity-2106-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions/multicolinearity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-normality-0276-nl/vufsw-normality-0276-nl.Rmd
+++ b/Assumptions/vufsw-normality-0276-nl/vufsw-normality-0276-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: assumptions/normality
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-normality-0277-nl/vufsw-normality-0277-nl.Rmd
+++ b/Assumptions/vufsw-normality-0277-nl/vufsw-normality-0277-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: assumptions/normality
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-ratio_of_variance-1377-nl/vufsw-ratio_of_variance-1377-nl.Rmd
+++ b/Assumptions/vufsw-ratio_of_variance-1377-nl/vufsw-ratio_of_variance-1377-nl.Rmd
@@ -77,6 +77,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/ratio of variance
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Assumptions/vufsw-residualplot-0077-nl/vufsw-residualplot-0077-nl.Rmd
+++ b/Assumptions/vufsw-residualplot-0077-nl/vufsw-residualplot-0077-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: assumptions/homoscedasticity/residual plot
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-sphericity-0264-nl/vufsw-sphericity-0264-nl.Rmd
+++ b/Assumptions/vufsw-sphericity-0264-nl/vufsw-sphericity-0264-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions/sphericity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-sphericity-0310-nl/vufsw-sphericity-0310-nl.Rmd
+++ b/Assumptions/vufsw-sphericity-0310-nl/vufsw-sphericity-0310-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: assumptions/sphericity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-0132-nl/vufsw-correlation-0132-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-0132-nl/vufsw-correlation-0132-nl.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1292-nl/vufsw-correlation-1292-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1292-nl/vufsw-correlation-1292-nl.Rmd
@@ -86,6 +86,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-correlation-1294-nl/vufsw-correlation-1294-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1294-nl/vufsw-correlation-1294-nl.Rmd
@@ -41,6 +41,6 @@ exsolution: solution
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1334-nl/vufsw-correlation-1334-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1334-nl/vufsw-correlation-1334-nl.Rmd
@@ -41,6 +41,6 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1336-nl/vufsw-correlation-1336-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1336-nl/vufsw-correlation-1336-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1338-nl/vufsw-correlation-1338-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1338-nl/vufsw-correlation-1338-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1351-nl/vufsw-correlation-1351-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1351-nl/vufsw-correlation-1351-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1352-nl/vufsw-correlation-1352-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1352-nl/vufsw-correlation-1352-nl.Rmd
@@ -70,6 +70,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Descriptive-statistics/vufsw-correlations-1030-nl/vufsw-correlations-1030-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1030-nl/vufsw-correlations-1030-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-correlations-1295-nl/vufsw-correlations-1295-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1295-nl/vufsw-correlations-1295-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlations-1296-nl/vufsw-correlations-1296-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1296-nl/vufsw-correlations-1296-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlations-1297-nl/vufsw-correlations-1297-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1297-nl/vufsw-correlations-1297-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-correlations-1298-nl/vufsw-correlations-1298-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1298-nl/vufsw-correlations-1298-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-covariance-1333-nl/vufsw-covariance-1333-nl.Rmd
+++ b/Descriptive-statistics/vufsw-covariance-1333-nl/vufsw-covariance-1333-nl.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/covariance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-covariance-1350-nl/vufsw-covariance-1350-nl.Rmd
+++ b/Descriptive-statistics/vufsw-covariance-1350-nl/vufsw-covariance-1350-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/covariance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-empiricalrule-0008-nl/vufsw-empiricalrule-0008-nl.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0008-nl/vufsw-empiricalrule-0008-nl.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-empiricalrule-0012-nl/vufsw-empiricalrule-0012-nl.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0012-nl/vufsw-empiricalrule-0012-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-empiricalrule-0027-nl/vufsw-empiricalrule-0027-nl.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0027-nl/vufsw-empiricalrule-0027-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-empiricalrule-0030-nl/vufsw-empiricalrule-0030-nl.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0030-nl/vufsw-empiricalrule-0030-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-graphs-0017-nl/vufsw-graphs-0017-nl.Rmd
+++ b/Descriptive-statistics/vufsw-graphs-0017-nl/vufsw-graphs-0017-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/data representation/graphs
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-graphs-0097-nl/vufsw-graphs-0097-nl.Rmd
+++ b/Descriptive-statistics/vufsw-graphs-0097-nl/vufsw-graphs-0097-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/data representation/graphs
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-histogram-0013-nl/vufsw-histogram-0013-nl.Rmd
+++ b/Descriptive-statistics/vufsw-histogram-0013-nl/vufsw-histogram-0013-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/data representation/graphs/histogram
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-inferentialstatistics-0131-nl/vufsw-inferentialstatistics-0131-nl.Rmd
+++ b/Descriptive-statistics/vufsw-inferentialstatistics-0131-nl/vufsw-inferentialstatistics-0131-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-measuresoflocation-0004-nl/vufsw-measuresoflocation-0004-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresoflocation-0004-nl/vufsw-measuresoflocation-0004-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of location
 exextra[Type]: conceptual
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-measuresofspread-0001-nl/vufsw-measuresofspread-0001-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0001-nl/vufsw-measuresofspread-0001-nl.Rmd
@@ -72,6 +72,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-measuresofspread-0035-nl/vufsw-measuresofspread-0035-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0035-nl/vufsw-measuresofspread-0035-nl.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: interpretation output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-measuresofspread-0069-nl/vufsw-measuresofspread-0069-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0069-nl/vufsw-measuresofspread-0069-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-measuresofspread-0125-nl/vufsw-measuresofspread-0125-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0125-nl/vufsw-measuresofspread-0125-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-mode-0024-nl/vufsw-mode-0024-nl.Rmd
+++ b/Descriptive-statistics/vufsw-mode-0024-nl/vufsw-mode-0024-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of location/mode
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-outliers-0018-nl/vufsw-outliers-0018-nl.Rmd
+++ b/Descriptive-statistics/vufsw-outliers-0018-nl/vufsw-outliers-0018-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/outliers
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-scatterplot-1113-nl/vufsw-scatterplot-1113-nl.Rmd
+++ b/Descriptive-statistics/vufsw-scatterplot-1113-nl/vufsw-scatterplot-1113-nl.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/data representation/graphs/scatterplot
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-standarddeviation-0020-nl/vufsw-standarddeviation-0020-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0020-nl/vufsw-standarddeviation-0020-nl.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standarddeviation-0036-nl/vufsw-standarddeviation-0036-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0036-nl/vufsw-standarddeviation-0036-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standarddeviation-0049-nl/vufsw-standarddeviation-0049-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0049-nl/vufsw-standarddeviation-0049-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standarddeviation-0085-nl/vufsw-standarddeviation-0085-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0085-nl/vufsw-standarddeviation-0085-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standarddeviation-0163-nl/vufsw-standarddeviation-0163-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0163-nl/vufsw-standarddeviation-0163-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Descriptive-statistics/vufsw-summarystatistics-0039-nl/vufsw-summarystatistics-0039-nl.Rmd
+++ b/Descriptive-statistics/vufsw-summarystatistics-0039-nl/vufsw-summarystatistics-0039-nl.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-width-0211-nl/vufsw-width-0211-nl.Rmd
+++ b/Descriptive-statistics/vufsw-width-0211-nl/vufsw-width-0211-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-0007-nl/vufsw-z-score-0007-nl.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-0007-nl/vufsw-z-score-0007-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-0009-nl/vufsw-z-score-0009-nl.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-0009-nl/vufsw-z-score-0009-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-0032-nl/vufsw-z-score-0032-nl.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-0032-nl/vufsw-z-score-0032-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-0096-nl/vufsw-z-score-0096-nl.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-0096-nl/vufsw-z-score-0096-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-1118-nl/vufsw-z-score-1118-nl.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-1118-nl/vufsw-z-score-1118-nl.Rmd
@@ -38,6 +38,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Factor-analysis/vufsw-explained_variance-2110-nl/vufsw-explained_variance-2110-nl.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2110-nl/vufsw-explained_variance-2110-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]: interpreting output 
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-explained_variance-2113-nl/vufsw-explained_variance-2113-nl.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2113-nl/vufsw-explained_variance-2113-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]:  Interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-explained_variance-2114-nl/vufsw-explained_variance-2114-nl.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2114-nl/vufsw-explained_variance-2114-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-factor_analysis-2109-nl/vufsw-factor_analysis-2109-nl.Rmd
+++ b/Factor-analysis/vufsw-factor_analysis-2109-nl/vufsw-factor_analysis-2109-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: factoranalysis
 exextra[Type]: output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-scree_plo-1299-nl/vufsw-scree_plo-1299-nl.Rmd
+++ b/Factor-analysis/vufsw-scree_plo-1299-nl/vufsw-scree_plo-1299-nl.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: factor analysis/scree plot
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-alternativehypothesis-0075-nl/vufsw-alternativehypothesis-0075-nl.Rmd
+++ b/Inferential_Statistics/vufsw-alternativehypothesis-0075-nl/vufsw-alternativehypothesis-0075-nl.Rmd
@@ -83,6 +83,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/alternative hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-alternativehypothesis-0223-nl/vufsw-alternativehypothesis-0223-nl.Rmd
+++ b/Inferential_Statistics/vufsw-alternativehypothesis-0223-nl/vufsw-alternativehypothesis-0223-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/alternative hypothesis
 exextra[Type]: test choise
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-analysis-1213-nl/vufsw-analysis-1213-nl.Rmd
+++ b/Inferential_Statistics/vufsw-analysis-1213-nl/vufsw-analysis-1213-nl.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: reliability/analysis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-ancova-0252-nl/vufsw-ancova-0252-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0252-nl/vufsw-ancova-0252-nl.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-ancova-0253-nl/vufsw-ancova-0253-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0253-nl/vufsw-ancova-0253-nl.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-ancova-0254-nl/vufsw-ancova-0254-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0254-nl/vufsw-ancova-0254-nl.Rmd
@@ -36,6 +36,6 @@ extol: 0.00499999999999989
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-ancova-0273-nl/vufsw-ancova-0273-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0273-nl/vufsw-ancova-0273-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-ancova-2069-nl/vufsw-ancova-2069-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2069-nl/vufsw-ancova-2069-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-ancova-2070-nl/vufsw-ancova-2070-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2070-nl/vufsw-ancova-2070-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-ancova-2071-nl/vufsw-ancova-2071-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2071-nl/vufsw-ancova-2071-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-ancova-2074-nl/vufsw-ancova-2074-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2074-nl/vufsw-ancova-2074-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-ancova-2075-nl/vufsw-ancova-2075-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2075-nl/vufsw-ancova-2075-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-ancova-2076-nl/vufsw-ancova-2076-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2076-nl/vufsw-ancova-2076-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-ancova-2077-nl/vufsw-ancova-2077-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2077-nl/vufsw-ancova-2077-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-anova_f-test-2068-nl/vufsw-anova_f-test-2068-nl.Rmd
+++ b/Inferential_Statistics/vufsw-anova_f-test-2068-nl/vufsw-anova_f-test-2068-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/anova f-test
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-anova_f-test-2073-nl/vufsw-anova_f-test-2073-nl.Rmd
+++ b/Inferential_Statistics/vufsw-anova_f-test-2073-nl/vufsw-anova_f-test-2073-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/anova f-test
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-anovaftest-0336-nl/vufsw-anovaftest-0336-nl.Rmd
+++ b/Inferential_Statistics/vufsw-anovaftest-0336-nl/vufsw-anovaftest-0336-nl.Rmd
@@ -43,6 +43,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/anova f-test
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-bootstrap-0291-nl/vufsw-bootstrap-0291-nl.Rmd
+++ b/Inferential_Statistics/vufsw-bootstrap-0291-nl/vufsw-bootstrap-0291-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/bootstrap
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-chisquared-0005-nl/vufsw-chisquared-0005-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0005-nl/vufsw-chisquared-0005-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-chisquared-0064-nl/vufsw-chisquared-0064-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0064-nl/vufsw-chisquared-0064-nl.Rmd
@@ -91,6 +91,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: interpretation output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-chisquared-0089-nl/vufsw-chisquared-0089-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0089-nl/vufsw-chisquared-0089-nl.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-chisquared-0092-nl/vufsw-chisquared-0092-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0092-nl/vufsw-chisquared-0092-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chisquared-0099-nl/vufsw-chisquared-0099-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0099-nl/vufsw-chisquared-0099-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chisquared-0112-nl/vufsw-chisquared-0112-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0112-nl/vufsw-chisquared-0112-nl.Rmd
@@ -93,6 +93,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: interpretating ouput
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0045-nl/vufsw-chisquaredforindependence-0045-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0045-nl/vufsw-chisquaredforindependence-0045-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0086-nl/vufsw-chisquaredforindependence-0086-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0086-nl/vufsw-chisquaredforindependence-0086-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0168-nl/vufsw-chisquaredforindependence-0168-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0168-nl/vufsw-chisquaredforindependence-0168-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0186-nl/vufsw-chisquaredforindependence-0186-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0186-nl/vufsw-chisquaredforindependence-0186-nl.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1301-nl/vufsw-coefficient_t-test-1301-nl.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1301-nl/vufsw-coefficient_t-test-1301-nl.Rmd
@@ -49,6 +49,6 @@ exsolution: solution
 exsection: inferential statistics/regression/coefficient t-test
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1353-nl/vufsw-coefficient_t-test-1353-nl.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1353-nl/vufsw-coefficient_t-test-1353-nl.Rmd
@@ -53,6 +53,6 @@ exsolution: solution
 exsection: inferential statistics/regression/coefficient t-test
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-coefficientttest-1187-nl/vufsw-coefficientttest-1187-nl.Rmd
+++ b/Inferential_Statistics/vufsw-coefficientttest-1187-nl/vufsw-coefficientttest-1187-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/coefficient t-test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_interval-1310-nl/vufsw-confidence_interval-1310-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_interval-1310-nl/vufsw-confidence_interval-1310-nl.Rmd
@@ -79,6 +79,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/confidence interval
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1339-nl/vufsw-confidence_intervals-1339-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1339-nl/vufsw-confidence_intervals-1339-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceinterval-0066-nl/vufsw-confidenceinterval-0066-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceinterval-0066-nl/vufsw-confidenceinterval-0066-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/confidence interval
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0038-nl/vufsw-confidenceintervals-0038-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0038-nl/vufsw-confidenceintervals-0038-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0043-nl/vufsw-confidenceintervals-0043-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0043-nl/vufsw-confidenceintervals-0043-nl.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0094-nl/vufsw-confidenceintervals-0094-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0094-nl/vufsw-confidenceintervals-0094-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0104-nl/vufsw-confidenceintervals-0104-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0104-nl/vufsw-confidenceintervals-0104-nl.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0142-nl/vufsw-confidenceintervals-0142-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0142-nl/vufsw-confidenceintervals-0142-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0185-nl/vufsw-confidenceintervals-0185-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0185-nl/vufsw-confidenceintervals-0185-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0187-nl/vufsw-confidenceintervals-0187-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0187-nl/vufsw-confidenceintervals-0187-nl.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0188-nl/vufsw-confidenceintervals-0188-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0188-nl/vufsw-confidenceintervals-0188-nl.Rmd
@@ -72,6 +72,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0228-nl/vufsw-confidenceintervals-0228-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0228-nl/vufsw-confidenceintervals-0228-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-correlation-1190-nl/vufsw-correlation-1190-nl.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1190-nl/vufsw-correlation-1190-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-correlation-1191-nl/vufsw-correlation-1191-nl.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1191-nl/vufsw-correlation-1191-nl.Rmd
@@ -38,6 +38,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-criticalvalue-0079-nl/vufsw-criticalvalue-0079-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0079-nl/vufsw-criticalvalue-0079-nl.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-criticalvalue-0080-nl/vufsw-criticalvalue-0080-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0080-nl/vufsw-criticalvalue-0080-nl.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-criticalvalue-0137-nl/vufsw-criticalvalue-0137-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0137-nl/vufsw-criticalvalue-0137-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-criticalvalue-0152-nl/vufsw-criticalvalue-0152-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0152-nl/vufsw-criticalvalue-0152-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-criticalvalue-0189-nl/vufsw-criticalvalue-0189-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0189-nl/vufsw-criticalvalue-0189-nl.Rmd
@@ -76,6 +76,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-crosstables-0002-nl/vufsw-crosstables-0002-nl.Rmd
+++ b/Inferential_Statistics/vufsw-crosstables-0002-nl/vufsw-crosstables-0002-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-dummies-2060-nl/vufsw-dummies-2060-nl.Rmd
+++ b/Inferential_Statistics/vufsw-dummies-2060-nl/vufsw-dummies-2060-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/dummies
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-dummies-2065-nl/vufsw-dummies-2065-nl.Rmd
+++ b/Inferential_Statistics/vufsw-dummies-2065-nl/vufsw-dummies-2065-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/dummies
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-dummies-2066-nl/vufsw-dummies-2066-nl.Rmd
+++ b/Inferential_Statistics/vufsw-dummies-2066-nl/vufsw-dummies-2066-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/dummies
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-equation-0014-nl/vufsw-equation-0014-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0014-nl/vufsw-equation-0014-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-0022-nl/vufsw-equation-0022-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0022-nl/vufsw-equation-0022-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-0040-nl/vufsw-equation-0040-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0040-nl/vufsw-equation-0040-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-0041-nl/vufsw-equation-0041-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0041-nl/vufsw-equation-0041-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: calculation
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-0106-nl/vufsw-equation-0106-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0106-nl/vufsw-equation-0106-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-0157-nl/vufsw-equation-0157-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0157-nl/vufsw-equation-0157-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1022-nl/vufsw-equation-1022-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1022-nl/vufsw-equation-1022-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1023-nl/vufsw-equation-1023-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1023-nl/vufsw-equation-1023-nl.Rmd
@@ -34,6 +34,6 @@ extol: 0
 exsection: inferential statistics/regression/equation
 exextra[Type]: performing analysis
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1026-nl/vufsw-equation-1026-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1026-nl/vufsw-equation-1026-nl.Rmd
@@ -84,6 +84,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-explainedvariance-0170-nl/vufsw-explainedvariance-0170-nl.Rmd
+++ b/Inferential_Statistics/vufsw-explainedvariance-0170-nl/vufsw-explainedvariance-0170-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1379-nl/vufsw-independent_samples_means-1379-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1379-nl/vufsw-independent_samples_means-1379-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1380-nl/vufsw-independent_samples_means-1380-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1380-nl/vufsw-independent_samples_means-1380-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1382-nl/vufsw-independent_samples_means-1382-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1382-nl/vufsw-independent_samples_means-1382-nl.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1383-nl/vufsw-independent_samples_means-1383-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1383-nl/vufsw-independent_samples_means-1383-nl.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-intercept-0095-nl/vufsw-intercept-0095-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-0095-nl/vufsw-intercept-0095-nl.Rmd
@@ -78,6 +78,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/intercept
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-intercept-0224-nl/vufsw-intercept-0224-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-0224-nl/vufsw-intercept-0224-nl.Rmd
@@ -68,6 +68,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/intercept
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-intercept-1119-nl/vufsw-intercept-1119-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-1119-nl/vufsw-intercept-1119-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/intercept
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-intercept-1355-nl/vufsw-intercept-1355-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-1355-nl/vufsw-intercept-1355-nl.Rmd
@@ -72,6 +72,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/intercept
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-0262-nl/vufsw-manova-0262-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0262-nl/vufsw-manova-0262-nl.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-0272-nl/vufsw-manova-0272-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0272-nl/vufsw-manova-0272-nl.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-0287-nl/vufsw-manova-0287-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0287-nl/vufsw-manova-0287-nl.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-0288-nl/vufsw-manova-0288-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0288-nl/vufsw-manova-0288-nl.Rmd
@@ -44,6 +44,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-0290-nl/vufsw-manova-0290-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0290-nl/vufsw-manova-0290-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1040-nl/vufsw-manova-1040-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1040-nl/vufsw-manova-1040-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: performing analysis
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-manova-1041-nl/vufsw-manova-1041-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1041-nl/vufsw-manova-1041-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1042-nl/vufsw-manova-1042-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1042-nl/vufsw-manova-1042-nl.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1043-nl/vufsw-manova-1043-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1043-nl/vufsw-manova-1043-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1046-nl/vufsw-manova-1046-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1046-nl/vufsw-manova-1046-nl.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1047-nl/vufsw-manova-1047-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1047-nl/vufsw-manova-1047-nl.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1067-nl/vufsw-manova-1067-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1067-nl/vufsw-manova-1067-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1070-nl/vufsw-manova-1070-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1070-nl/vufsw-manova-1070-nl.Rmd
@@ -35,6 +35,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1073-nl/vufsw-manova-1073-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1073-nl/vufsw-manova-1073-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-0015-nl/vufsw-mediation-0015-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0015-nl/vufsw-mediation-0015-nl.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0127-nl/vufsw-mediation-0127-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0127-nl/vufsw-mediation-0127-nl.Rmd
@@ -89,6 +89,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-0247-nl/vufsw-mediation-0247-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0247-nl/vufsw-mediation-0247-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0248-nl/vufsw-mediation-0248-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0248-nl/vufsw-mediation-0248-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0268-nl/vufsw-mediation-0268-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0268-nl/vufsw-mediation-0268-nl.Rmd
@@ -36,6 +36,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-0292-nl/vufsw-mediation-0292-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0292-nl/vufsw-mediation-0292-nl.Rmd
@@ -36,6 +36,6 @@ extol: 0.01
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-0293-nl/vufsw-mediation-0293-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0293-nl/vufsw-mediation-0293-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0294-nl/vufsw-mediation-0294-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0294-nl/vufsw-mediation-0294-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0295-nl/vufsw-mediation-0295-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0295-nl/vufsw-mediation-0295-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0296-nl/vufsw-mediation-0296-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0296-nl/vufsw-mediation-0296-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0297-nl/vufsw-mediation-0297-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0297-nl/vufsw-mediation-0297-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0298-nl/vufsw-mediation-0298-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0298-nl/vufsw-mediation-0298-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-0299-nl/vufsw-mediation-0299-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0299-nl/vufsw-mediation-0299-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0300-nl/vufsw-mediation-0300-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0300-nl/vufsw-mediation-0300-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0301-nl/vufsw-mediation-0301-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0301-nl/vufsw-mediation-0301-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0302-nl/vufsw-mediation-0302-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0302-nl/vufsw-mediation-0302-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0303-nl/vufsw-mediation-0303-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0303-nl/vufsw-mediation-0303-nl.Rmd
@@ -48,6 +48,6 @@ extol: 0.000999999999999945
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-0304-nl/vufsw-mediation-0304-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0304-nl/vufsw-mediation-0304-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-0305-nl/vufsw-mediation-0305-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0305-nl/vufsw-mediation-0305-nl.Rmd
@@ -40,6 +40,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-1033-nl/vufsw-mediation-1033-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1033-nl/vufsw-mediation-1033-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning<br/>
 

--- a/Inferential_Statistics/vufsw-mediation-1361-nl/vufsw-mediation-1361-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1361-nl/vufsw-mediation-1361-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1362-nl/vufsw-mediation-1362-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1362-nl/vufsw-mediation-1362-nl.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-1363-nl/vufsw-mediation-1363-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1363-nl/vufsw-mediation-1363-nl.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-1364-nl/vufsw-mediation-1364-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1364-nl/vufsw-mediation-1364-nl.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1365-nl/vufsw-mediation-1365-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1365-nl/vufsw-mediation-1365-nl.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1366-nl/vufsw-mediation-1366-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1366-nl/vufsw-mediation-1366-nl.Rmd
@@ -55,6 +55,6 @@ exsolution: solution
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1367-nl/vufsw-mediation-1367-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1367-nl/vufsw-mediation-1367-nl.Rmd
@@ -55,6 +55,6 @@ exsolution: -0.008
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-1368-nl/vufsw-mediation-1368-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1368-nl/vufsw-mediation-1368-nl.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1369-nl/vufsw-mediation-1369-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1369-nl/vufsw-mediation-1369-nl.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-2002-nl/vufsw-mediation-2002-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2002-nl/vufsw-mediation-2002-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2003-nl/vufsw-mediation-2003-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2003-nl/vufsw-mediation-2003-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2004-nl/vufsw-mediation-2004-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2004-nl/vufsw-mediation-2004-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2005-nl/vufsw-mediation-2005-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2005-nl/vufsw-mediation-2005-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2006-nl/vufsw-mediation-2006-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2006-nl/vufsw-mediation-2006-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2007-nl/vufsw-mediation-2007-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2007-nl/vufsw-mediation-2007-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2008-nl/vufsw-mediation-2008-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2008-nl/vufsw-mediation-2008-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2009-nl/vufsw-mediation-2009-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2009-nl/vufsw-mediation-2009-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2010-nl/vufsw-mediation-2010-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2010-nl/vufsw-mediation-2010-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2012-nl/vufsw-mediation-2012-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2012-nl/vufsw-mediation-2012-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2013-nl/vufsw-mediation-2013-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2013-nl/vufsw-mediation-2013-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2014-nl/vufsw-mediation-2014-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2014-nl/vufsw-mediation-2014-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2015-nl/vufsw-mediation-2015-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2015-nl/vufsw-mediation-2015-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2016-nl/vufsw-mediation-2016-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2016-nl/vufsw-mediation-2016-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2017-nl/vufsw-mediation-2017-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2017-nl/vufsw-mediation-2017-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-2018-nl/vufsw-mediation-2018-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2018-nl/vufsw-mediation-2018-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2019-nl/vufsw-mediation-2019-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2019-nl/vufsw-mediation-2019-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2020-nl/vufsw-mediation-2020-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2020-nl/vufsw-mediation-2020-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2021-nl/vufsw-mediation-2021-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2021-nl/vufsw-mediation-2021-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2022-nl/vufsw-mediation-2022-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2022-nl/vufsw-mediation-2022-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2023-nl/vufsw-mediation-2023-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2023-nl/vufsw-mediation-2023-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2024-nl/vufsw-mediation-2024-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2024-nl/vufsw-mediation-2024-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2025-nl/vufsw-mediation-2025-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2025-nl/vufsw-mediation-2025-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2026-nl/vufsw-mediation-2026-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2026-nl/vufsw-mediation-2026-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2027-nl/vufsw-mediation-2027-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2027-nl/vufsw-mediation-2027-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2028-nl/vufsw-mediation-2028-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2028-nl/vufsw-mediation-2028-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2029-nl/vufsw-mediation-2029-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2029-nl/vufsw-mediation-2029-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2030-nl/vufsw-mediation-2030-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2030-nl/vufsw-mediation-2030-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-2031-nl/vufsw-mediation-2031-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2031-nl/vufsw-mediation-2031-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1058-nl/vufsw-mixed_design_anova-1058-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1058-nl/vufsw-mixed_design_anova-1058-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1059-nl/vufsw-mixed_design_anova-1059-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1059-nl/vufsw-mixed_design_anova-1059-nl.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1060-nl/vufsw-mixed_design_anova-1060-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1060-nl/vufsw-mixed_design_anova-1060-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1061-nl/vufsw-mixed_design_anova-1061-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1061-nl/vufsw-mixed_design_anova-1061-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1062-nl/vufsw-mixed_design_anova-1062-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1062-nl/vufsw-mixed_design_anova-1062-nl.Rmd
@@ -78,6 +78,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpreting out
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1064-nl/vufsw-mixed_design_anova-1064-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1064-nl/vufsw-mixed_design_anova-1064-nl.Rmd
@@ -63,6 +63,6 @@ extol: 0.000399999999999998
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpreting out
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1065-nl/vufsw-mixed_design_anova-1065-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1065-nl/vufsw-mixed_design_anova-1065-nl.Rmd
@@ -58,6 +58,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpreting out
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1074-nl/vufsw-mixed_design_anova-1074-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1074-nl/vufsw-mixed_design_anova-1074-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0267-nl/vufsw-mixeddesignanova-0267-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0267-nl/vufsw-mixeddesignanova-0267-nl.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0269-nl/vufsw-mixeddesignanova-0269-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0269-nl/vufsw-mixeddesignanova-0269-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0308-nl/vufsw-mixeddesignanova-0308-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0308-nl/vufsw-mixeddesignanova-0308-nl.Rmd
@@ -42,6 +42,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0320-nl/vufsw-mixeddesignanova-0320-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0320-nl/vufsw-mixeddesignanova-0320-nl.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0322-nl/vufsw-mixeddesignanova-0322-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0322-nl/vufsw-mixeddesignanova-0322-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0324-nl/vufsw-mixeddesignanova-0324-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0324-nl/vufsw-mixeddesignanova-0324-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0337-nl/vufsw-mixeddesignanova-0337-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0337-nl/vufsw-mixeddesignanova-0337-nl.Rmd
@@ -45,6 +45,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0016-nl/vufsw-moderation-0016-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0016-nl/vufsw-moderation-0016-nl.Rmd
@@ -76,6 +76,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-0028-nl/vufsw-moderation-0028-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0028-nl/vufsw-moderation-0028-nl.Rmd
@@ -70,6 +70,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-0115-nl/vufsw-moderation-0115-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0115-nl/vufsw-moderation-0115-nl.Rmd
@@ -93,6 +93,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpretating output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-0169-nl/vufsw-moderation-0169-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0169-nl/vufsw-moderation-0169-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpretating graph
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0222-nl/vufsw-moderation-0222-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0222-nl/vufsw-moderation-0222-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-0230-nl/vufsw-moderation-0230-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0230-nl/vufsw-moderation-0230-nl.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpretating graph
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0243-nl/vufsw-moderation-0243-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0243-nl/vufsw-moderation-0243-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: performing analysis
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-0244-nl/vufsw-moderation-0244-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0244-nl/vufsw-moderation-0244-nl.Rmd
@@ -78,6 +78,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0311-nl/vufsw-moderation-0311-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0311-nl/vufsw-moderation-0311-nl.Rmd
@@ -44,6 +44,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0312-nl/vufsw-moderation-0312-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0312-nl/vufsw-moderation-0312-nl.Rmd
@@ -44,6 +44,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0318-nl/vufsw-moderation-0318-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0318-nl/vufsw-moderation-0318-nl.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0323-nl/vufsw-moderation-0323-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0323-nl/vufsw-moderation-0323-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-1020-nl/vufsw-moderation-1020-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1020-nl/vufsw-moderation-1020-nl.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1021-nl/vufsw-moderation-1021-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1021-nl/vufsw-moderation-1021-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1305-nl/vufsw-moderation-1305-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1305-nl/vufsw-moderation-1305-nl.Rmd
@@ -53,6 +53,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculation
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1306-nl/vufsw-moderation-1306-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1306-nl/vufsw-moderation-1306-nl.Rmd
@@ -73,6 +73,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-1348-nl/vufsw-moderation-1348-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1348-nl/vufsw-moderation-1348-nl.Rmd
@@ -82,6 +82,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1356-nl/vufsw-moderation-1356-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1356-nl/vufsw-moderation-1356-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1357-nl/vufsw-moderation-1357-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1357-nl/vufsw-moderation-1357-nl.Rmd
@@ -68,6 +68,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpeting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-1358-nl/vufsw-moderation-1358-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1358-nl/vufsw-moderation-1358-nl.Rmd
@@ -77,6 +77,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-1359-nl/vufsw-moderation-1359-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1359-nl/vufsw-moderation-1359-nl.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2035-nl/vufsw-moderation-2035-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2035-nl/vufsw-moderation-2035-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2036-nl/vufsw-moderation-2036-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2036-nl/vufsw-moderation-2036-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2037-nl/vufsw-moderation-2037-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2037-nl/vufsw-moderation-2037-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2040-nl/vufsw-moderation-2040-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2040-nl/vufsw-moderation-2040-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2041-nl/vufsw-moderation-2041-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2041-nl/vufsw-moderation-2041-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2042-nl/vufsw-moderation-2042-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2042-nl/vufsw-moderation-2042-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2045-nl/vufsw-moderation-2045-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2045-nl/vufsw-moderation-2045-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2047-nl/vufsw-moderation-2047-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2047-nl/vufsw-moderation-2047-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2048-nl/vufsw-moderation-2048-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2048-nl/vufsw-moderation-2048-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2050-nl/vufsw-moderation-2050-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2050-nl/vufsw-moderation-2050-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2051-nl/vufsw-moderation-2051-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2051-nl/vufsw-moderation-2051-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2052-nl/vufsw-moderation-2052-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2052-nl/vufsw-moderation-2052-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2053-nl/vufsw-moderation-2053-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2053-nl/vufsw-moderation-2053-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2078-nl/vufsw-moderation-2078-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2078-nl/vufsw-moderation-2078-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2079-nl/vufsw-moderation-2079-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2079-nl/vufsw-moderation-2079-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2080-nl/vufsw-moderation-2080-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2080-nl/vufsw-moderation-2080-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2081-nl/vufsw-moderation-2081-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2081-nl/vufsw-moderation-2081-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2082-nl/vufsw-moderation-2082-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2082-nl/vufsw-moderation-2082-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2083-nl/vufsw-moderation-2083-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2083-nl/vufsw-moderation-2083-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2084-nl/vufsw-moderation-2084-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2084-nl/vufsw-moderation-2084-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-moderation-2085-nl/vufsw-moderation-2085-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2085-nl/vufsw-moderation-2085-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2090-nl/vufsw-moderation-2090-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2090-nl/vufsw-moderation-2090-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2094-nl/vufsw-moderation-2094-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2094-nl/vufsw-moderation-2094-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-2095-nl/vufsw-moderation-2095-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2095-nl/vufsw-moderation-2095-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2099-nl/vufsw-moderation-2099-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2099-nl/vufsw-moderation-2099-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-2100-nl/vufsw-moderation-2100-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2100-nl/vufsw-moderation-2100-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-2104-nl/vufsw-moderation-2104-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2104-nl/vufsw-moderation-2104-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-2105-nl/vufsw-moderation-2105-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2105-nl/vufsw-moderation-2105-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1303-nl/vufsw-multiple_linear_regression-1303-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1303-nl/vufsw-multiple_linear_regression-1303-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1307-nl/vufsw-multiple_linear_regression-1307-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1307-nl/vufsw-multiple_linear_regression-1307-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1354-nl/vufsw-multiple_linear_regression-1354-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1354-nl/vufsw-multiple_linear_regression-1354-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2088-nl/vufsw-multiple_linear_regression-2088-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2088-nl/vufsw-multiple_linear_regression-2088-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2093-nl/vufsw-multiple_linear_regression-2093-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2093-nl/vufsw-multiple_linear_regression-2093-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2098-nl/vufsw-multiple_linear_regression-2098-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2098-nl/vufsw-multiple_linear_regression-2098-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2103-nl/vufsw-multiple_linear_regression-2103-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2103-nl/vufsw-multiple_linear_regression-2103-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiplelinearregression-0275-nl/vufsw-multiplelinearregression-0275-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-0275-nl/vufsw-multiplelinearregression-0275-nl.Rmd
@@ -33,6 +33,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiplelinearregression-0281-nl/vufsw-multiplelinearregression-0281-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-0281-nl/vufsw-multiplelinearregression-0281-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiplelinearregression-0328-nl/vufsw-multiplelinearregression-0328-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-0328-nl/vufsw-multiplelinearregression-0328-nl.Rmd
@@ -48,6 +48,6 @@ extol: 0.01
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-nhst-0162-nl/vufsw-nhst-0162-nl.Rmd
+++ b/Inferential_Statistics/vufsw-nhst-0162-nl/vufsw-nhst-0162-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-nhst-1194-nl/vufsw-nhst-1194-nl.Rmd
+++ b/Inferential_Statistics/vufsw-nhst-1194-nl/vufsw-nhst-1194-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-nullhypothesis-0100-nl/vufsw-nullhypothesis-0100-nl.Rmd
+++ b/Inferential_Statistics/vufsw-nullhypothesis-0100-nl/vufsw-nullhypothesis-0100-nl.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/null hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-nullhypothesis-0227-nl/vufsw-nullhypothesis-0227-nl.Rmd
+++ b/Inferential_Statistics/vufsw-nullhypothesis-0227-nl/vufsw-nullhypothesis-0227-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/null hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-omega_squared-1372-nl/vufsw-omega_squared-1372-nl.Rmd
+++ b/Inferential_Statistics/vufsw-omega_squared-1372-nl/vufsw-omega_squared-1372-nl.Rmd
@@ -53,6 +53,6 @@ exsolution: solution
 exsection: inferential statistics/effect size/omega squared
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onesidedhypothesis-0059-nl/vufsw-onesidedhypothesis-0059-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onesidedhypothesis-0059-nl/vufsw-onesidedhypothesis-0059-nl.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/one sided hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onesidedhypothesis-0074-nl/vufsw-onesidedhypothesis-0074-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onesidedhypothesis-0074-nl/vufsw-onesidedhypothesis-0074-nl.Rmd
@@ -86,6 +86,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/one sided hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onesidedhypothesis-0120-nl/vufsw-onesidedhypothesis-0120-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onesidedhypothesis-0120-nl/vufsw-onesidedhypothesis-0120-nl.Rmd
@@ -72,6 +72,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/one sided hypothesis
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1318-nl/vufsw-oneway_anova-1318-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1318-nl/vufsw-oneway_anova-1318-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1319-nl/vufsw-oneway_anova-1319-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1319-nl/vufsw-oneway_anova-1319-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1320-nl/vufsw-oneway_anova-1320-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1320-nl/vufsw-oneway_anova-1320-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1321-nl/vufsw-oneway_anova-1321-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1321-nl/vufsw-oneway_anova-1321-nl.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1370-nl/vufsw-oneway_anova-1370-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1370-nl/vufsw-oneway_anova-1370-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1371-nl/vufsw-oneway_anova-1371-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1371-nl/vufsw-oneway_anova-1371-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-oneway_anova-1373-nl/vufsw-oneway_anova-1373-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1373-nl/vufsw-oneway_anova-1373-nl.Rmd
@@ -73,6 +73,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-onewayanova-0255-nl/vufsw-onewayanova-0255-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0255-nl/vufsw-onewayanova-0255-nl.Rmd
@@ -75,6 +75,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0256-nl/vufsw-onewayanova-0256-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0256-nl/vufsw-onewayanova-0256-nl.Rmd
@@ -105,6 +105,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0257-nl/vufsw-onewayanova-0257-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0257-nl/vufsw-onewayanova-0257-nl.Rmd
@@ -105,6 +105,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0258-nl/vufsw-onewayanova-0258-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0258-nl/vufsw-onewayanova-0258-nl.Rmd
@@ -104,6 +104,6 @@ extol: 0.01
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0270-nl/vufsw-onewayanova-0270-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0270-nl/vufsw-onewayanova-0270-nl.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statisitcal reasoning
 

--- a/Inferential_Statistics/vufsw-onewayanova-0316-nl/vufsw-onewayanova-0316-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0316-nl/vufsw-onewayanova-0316-nl.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onewayanova-0317-nl/vufsw-onewayanova-0317-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0317-nl/vufsw-onewayanova-0317-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-onewayanova-0345-nl/vufsw-onewayanova-0345-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0345-nl/vufsw-onewayanova-0345-nl.Rmd
@@ -36,6 +36,6 @@ extol: 0.0999999999999996
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-onewayanova-1285-nl/vufsw-onewayanova-1285-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1285-nl/vufsw-onewayanova-1285-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onewayanova-1286-nl/vufsw-onewayanova-1286-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1286-nl/vufsw-onewayanova-1286-nl.Rmd
@@ -45,6 +45,6 @@ exsolution: solution
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onewayanova-1287-nl/vufsw-onewayanova-1287-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1287-nl/vufsw-onewayanova-1287-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onewayanova-1289-nl/vufsw-onewayanova-1289-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1289-nl/vufsw-onewayanova-1289-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpreting output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0319-nl/vufsw-onewayrepeatedmeasuresanova-0319-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0319-nl/vufsw-onewayrepeatedmeasuresanova-0319-nl.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway repeated measures anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0321-nl/vufsw-onewayrepeatedmeasuresanova-0321-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0321-nl/vufsw-onewayrepeatedmeasuresanova-0321-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway repeated measures anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0334-nl/vufsw-onewayrepeatedmeasuresanova-0334-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0334-nl/vufsw-onewayrepeatedmeasuresanova-0334-nl.Rmd
@@ -27,6 +27,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway repeated measures anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pairedsamples-0146-nl/vufsw-pairedsamples-0146-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pairedsamples-0146-nl/vufsw-pairedsamples-0146-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t test/paired samples
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-pearson-1332-nl/vufsw-pearson-1332-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pearson-1332-nl/vufsw-pearson-1332-nl.Rmd
@@ -40,6 +40,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/correlations/pearson
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-pearson-1349-nl/vufsw-pearson-1349-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pearson-1349-nl/vufsw-pearson-1349-nl.Rmd
@@ -38,6 +38,6 @@ exsolution: 0.40
 exsection: inferential statistics/parametric techniques/correlations/pearson
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-0067-nl/vufsw-prediction-0067-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-0067-nl/vufsw-prediction-0067-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2055-nl/vufsw-prediction-2055-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2055-nl/vufsw-prediction-2055-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2056-nl/vufsw-prediction-2056-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2056-nl/vufsw-prediction-2056-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2058-nl/vufsw-prediction-2058-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2058-nl/vufsw-prediction-2058-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2059-nl/vufsw-prediction-2059-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2059-nl/vufsw-prediction-2059-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2063-nl/vufsw-prediction-2063-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2063-nl/vufsw-prediction-2063-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2064-nl/vufsw-prediction-2064-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2064-nl/vufsw-prediction-2064-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2087-nl/vufsw-prediction-2087-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2087-nl/vufsw-prediction-2087-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2092-nl/vufsw-prediction-2092-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2092-nl/vufsw-prediction-2092-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-prediction-2096-nl/vufsw-prediction-2096-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2096-nl/vufsw-prediction-2096-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/prediction
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0019-nl/vufsw-pvalue-0019-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0019-nl/vufsw-pvalue-0019-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0033-nl/vufsw-pvalue-0033-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0033-nl/vufsw-pvalue-0033-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0073-nl/vufsw-pvalue-0073-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0073-nl/vufsw-pvalue-0073-nl.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0088-nl/vufsw-pvalue-0088-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0088-nl/vufsw-pvalue-0088-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0091-nl/vufsw-pvalue-0091-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0091-nl/vufsw-pvalue-0091-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0102-nl/vufsw-pvalue-0102-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0102-nl/vufsw-pvalue-0102-nl.Rmd
@@ -90,6 +90,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0138-nl/vufsw-pvalue-0138-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0138-nl/vufsw-pvalue-0138-nl.Rmd
@@ -82,6 +82,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0194-nl/vufsw-pvalue-0194-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0194-nl/vufsw-pvalue-0194-nl.Rmd
@@ -70,6 +70,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-pvalue-0199-nl/vufsw-pvalue-0199-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0199-nl/vufsw-pvalue-0199-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0216-nl/vufsw-pvalue-0216-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0216-nl/vufsw-pvalue-0216-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-pvalue-0231-nl/vufsw-pvalue-0231-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0231-nl/vufsw-pvalue-0231-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-r_squared_change-1028-nl/vufsw-r_squared_change-1028-nl.Rmd
+++ b/Inferential_Statistics/vufsw-r_squared_change-1028-nl/vufsw-r_squared_change-1028-nl.Rmd
@@ -79,6 +79,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/r squared change
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-r_squared_change-2057-nl/vufsw-r_squared_change-2057-nl.Rmd
+++ b/Inferential_Statistics/vufsw-r_squared_change-2057-nl/vufsw-r_squared_change-2057-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/r squared change
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-r_squared_change-2061-nl/vufsw-r_squared_change-2061-nl.Rmd
+++ b/Inferential_Statistics/vufsw-r_squared_change-2061-nl/vufsw-r_squared_change-2061-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/r squared change
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-ratio_of_variance-1330-nl/vufsw-ratio_of_variance-1330-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ratio_of_variance-1330-nl/vufsw-ratio_of_variance-1330-nl.Rmd
@@ -83,6 +83,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/ratio of variance
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-regression-0006-nl/vufsw-regression-0006-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-0006-nl/vufsw-regression-0006-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-regression-0031-nl/vufsw-regression-0031-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-0031-nl/vufsw-regression-0031-nl.Rmd
@@ -73,6 +73,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: interpretation output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-regression-0072-nl/vufsw-regression-0072-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-0072-nl/vufsw-regression-0072-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-regression-1115-nl/vufsw-regression-1115-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-1115-nl/vufsw-regression-1115-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-residuals-0037-nl/vufsw-residuals-0037-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-0037-nl/vufsw-residuals-0037-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/residuals
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-residuals-0101-nl/vufsw-residuals-0101-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-0101-nl/vufsw-residuals-0101-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/residuals
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-residuals-0171-nl/vufsw-residuals-0171-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-0171-nl/vufsw-residuals-0171-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/residuals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-residuals-0175-nl/vufsw-residuals-0175-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-0175-nl/vufsw-residuals-0175-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/residuals
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-residuals-1308-nl/vufsw-residuals-1308-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-1308-nl/vufsw-residuals-1308-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/residuals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-rsquared-0047-nl/vufsw-rsquared-0047-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0047-nl/vufsw-rsquared-0047-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-0048-nl/vufsw-rsquared-0048-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0048-nl/vufsw-rsquared-0048-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-0065-nl/vufsw-rsquared-0065-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0065-nl/vufsw-rsquared-0065-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-0087-nl/vufsw-rsquared-0087-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0087-nl/vufsw-rsquared-0087-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-0119-nl/vufsw-rsquared-0119-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0119-nl/vufsw-rsquared-0119-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-0121-nl/vufsw-rsquared-0121-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0121-nl/vufsw-rsquared-0121-nl.Rmd
@@ -85,6 +85,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-rsquared-0221-nl/vufsw-rsquared-0221-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0221-nl/vufsw-rsquared-0221-nl.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-0226-nl/vufsw-rsquared-0226-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0226-nl/vufsw-rsquared-0226-nl.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-rsquared-0229-nl/vufsw-rsquared-0229-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0229-nl/vufsw-rsquared-0229-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-samplingdistributions-0082-nl/vufsw-samplingdistributions-0082-nl.Rmd
+++ b/Inferential_Statistics/vufsw-samplingdistributions-0082-nl/vufsw-samplingdistributions-0082-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/sampling distributions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-significancelevel-0021-nl/vufsw-significancelevel-0021-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0021-nl/vufsw-significancelevel-0021-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-significancelevel-0023-nl/vufsw-significancelevel-0023-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0023-nl/vufsw-significancelevel-0023-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-significancelevel-0156-nl/vufsw-significancelevel-0156-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0156-nl/vufsw-significancelevel-0156-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-significancelevel-0191-nl/vufsw-significancelevel-0191-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0191-nl/vufsw-significancelevel-0191-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-significancelevel-0198-nl/vufsw-significancelevel-0198-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0198-nl/vufsw-significancelevel-0198-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-significancelevel-0212-nl/vufsw-significancelevel-0212-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0212-nl/vufsw-significancelevel-0212-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-significancelevel-1103-nl/vufsw-significancelevel-1103-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-1103-nl/vufsw-significancelevel-1103-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-simple_linear_regression-0219-nl/vufsw-simple_linear_regression-0219-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simple_linear_regression-0219-nl/vufsw-simple_linear_regression-0219-nl.Rmd
@@ -68,6 +68,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: interpretating graph
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-0076-nl/vufsw-simplelinearregression-0076-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0076-nl/vufsw-simplelinearregression-0076-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-0098-nl/vufsw-simplelinearregression-0098-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0098-nl/vufsw-simplelinearregression-0098-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-0166-nl/vufsw-simplelinearregression-0166-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0166-nl/vufsw-simplelinearregression-0166-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: interpretating graph
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-0274-nl/vufsw-simplelinearregression-0274-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0274-nl/vufsw-simplelinearregression-0274-nl.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-0330-nl/vufsw-simplelinearregression-0330-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0330-nl/vufsw-simplelinearregression-0330-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-0107-nl/vufsw-slope-0107-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0107-nl/vufsw-slope-0107-nl.Rmd
@@ -90,6 +90,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpretating output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-0143-nl/vufsw-slope-0143-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0143-nl/vufsw-slope-0143-nl.Rmd
@@ -90,6 +90,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-0151-nl/vufsw-slope-0151-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0151-nl/vufsw-slope-0151-nl.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-0220-nl/vufsw-slope-0220-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0220-nl/vufsw-slope-0220-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1302-nl/vufsw-slope-1302-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1302-nl/vufsw-slope-1302-nl.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1304-nl/vufsw-slope-1304-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1304-nl/vufsw-slope-1304-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1309-nl/vufsw-slope-1309-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1309-nl/vufsw-slope-1309-nl.Rmd
@@ -72,6 +72,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2038/vufsw-slope-2038.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2038/vufsw-slope-2038.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2039-nl/vufsw-slope-2039-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2039-nl/vufsw-slope-2039-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2043-nl/vufsw-slope-2043-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2043-nl/vufsw-slope-2043-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2044-nl/vufsw-slope-2044-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2044-nl/vufsw-slope-2044-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2046-nl/vufsw-slope-2046-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2046-nl/vufsw-slope-2046-nl.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2049-nl/vufsw-slope-2049-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2049-nl/vufsw-slope-2049-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2054-nl/vufsw-slope-2054-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2054-nl/vufsw-slope-2054-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2062-nl/vufsw-slope-2062-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2062-nl/vufsw-slope-2062-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2086-nl/vufsw-slope-2086-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2086-nl/vufsw-slope-2086-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2089-nl/vufsw-slope-2089-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2089-nl/vufsw-slope-2089-nl.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2091-nl/vufsw-slope-2091-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2091-nl/vufsw-slope-2091-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2097-nl/vufsw-slope-2097-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2097-nl/vufsw-slope-2097-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2101-nl/vufsw-slope-2101-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2101-nl/vufsw-slope-2101-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-2102-nl/vufsw-slope-2102-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2102-nl/vufsw-slope-2102-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-standarderroroftheestimate-0083-nl/vufsw-standarderroroftheestimate-0083-nl.Rmd
+++ b/Inferential_Statistics/vufsw-standarderroroftheestimate-0083-nl/vufsw-standarderroroftheestimate-0083-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standard error of the estimate
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-standardizedcoefficient-0010-nl/vufsw-standardizedcoefficient-0010-nl.Rmd
+++ b/Inferential_Statistics/vufsw-standardizedcoefficient-0010-nl/vufsw-standardizedcoefficient-0010-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standardized coefficient
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-standardizedcoefficient-0155-nl/vufsw-standardizedcoefficient-0155-nl.Rmd
+++ b/Inferential_Statistics/vufsw-standardizedcoefficient-0155-nl/vufsw-standardizedcoefficient-0155-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standardized coefficient
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-standardizedcoefficient-0329-nl/vufsw-standardizedcoefficient-0329-nl.Rmd
+++ b/Inferential_Statistics/vufsw-standardizedcoefficient-0329-nl/vufsw-standardizedcoefficient-0329-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standardized coefficient
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-sum_of_squares-1053-nl/vufsw-sum_of_squares-1053-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sum_of_squares-1053-nl/vufsw-sum_of_squares-1053-nl.Rmd
@@ -101,6 +101,6 @@ extol: 0
 exsection:  inferential statistics/regression/sum of squares
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-sum_of_squares-2067-nl/vufsw-sum_of_squares-2067-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sum_of_squares-2067-nl/vufsw-sum_of_squares-2067-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/sum of squares
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-sum_of_squares-2072-nl/vufsw-sum_of_squares-2072-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sum_of_squares-2072-nl/vufsw-sum_of_squares-2072-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/sum of squares
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-sumofsquares-0003-nl/vufsw-sumofsquares-0003-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sumofsquares-0003-nl/vufsw-sumofsquares-0003-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/sum of squares
 exextra[Type]: interpretating graph
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-t-test-1323-nl/vufsw-t-test-1323-nl.Rmd
+++ b/Inferential_Statistics/vufsw-t-test-1323-nl/vufsw-t-test-1323-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-t-test-1326-nl/vufsw-t-test-1326-nl.Rmd
+++ b/Inferential_Statistics/vufsw-t-test-1326-nl/vufsw-t-test-1326-nl.Rmd
@@ -79,6 +79,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-testing-0200-nl/vufsw-testing-0200-nl.Rmd
+++ b/Inferential_Statistics/vufsw-testing-0200-nl/vufsw-testing-0200-nl.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence Intervals/testing
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-testing-1102-nl/vufsw-testing-1102-nl.Rmd
+++ b/Inferential_Statistics/vufsw-testing-1102-nl/vufsw-testing-1102-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/testing
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-tstatistic-0081-nl/vufsw-tstatistic-0081-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0081-nl/vufsw-tstatistic-0081-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t statistic
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-tstatistic-0084-nl/vufsw-tstatistic-0084-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0084-nl/vufsw-tstatistic-0084-nl.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t statistic
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-tstatistic-0111-nl/vufsw-tstatistic-0111-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0111-nl/vufsw-tstatistic-0111-nl.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t statistic
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-tstatistic-0190-nl/vufsw-tstatistic-0190-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0190-nl/vufsw-tstatistic-0190-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t statistic
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-tstatistic-0225-nl/vufsw-tstatistic-0225-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0225-nl/vufsw-tstatistic-0225-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t statistic
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-twoway_anova-0271-nl/vufsw-twoway_anova-0271-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-0271-nl/vufsw-twoway_anova-0271-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1327-nl/vufsw-twoway_anova-1327-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1327-nl/vufsw-twoway_anova-1327-nl.Rmd
@@ -60,6 +60,6 @@ exsolution: 75.75
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1328-nl/vufsw-twoway_anova-1328-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1328-nl/vufsw-twoway_anova-1328-nl.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1329-nl/vufsw-twoway_anova-1329-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1329-nl/vufsw-twoway_anova-1329-nl.Rmd
@@ -77,6 +77,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1331-nl/vufsw-twoway_anova-1331-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1331-nl/vufsw-twoway_anova-1331-nl.Rmd
@@ -80,6 +80,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1374-nl/vufsw-twoway_anova-1374-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1374-nl/vufsw-twoway_anova-1374-nl.Rmd
@@ -53,6 +53,6 @@ exsolution: 184.76
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1375-nl/vufsw-twoway_anova-1375-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1375-nl/vufsw-twoway_anova-1375-nl.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1376-nl/vufsw-twoway_anova-1376-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1376-nl/vufsw-twoway_anova-1376-nl.Rmd
@@ -70,6 +70,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1378-nl/vufsw-twoway_anova-1378-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1378-nl/vufsw-twoway_anova-1378-nl.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-typeierror-0195-nl/vufsw-typeierror-0195-nl.Rmd
+++ b/Inferential_Statistics/vufsw-typeierror-0195-nl/vufsw-typeierror-0195-nl.Rmd
@@ -79,6 +79,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/statistical errors/type I error
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-typeierror-0217-nl/vufsw-typeierror-0217-nl.Rmd
+++ b/Inferential_Statistics/vufsw-typeierror-0217-nl/vufsw-typeierror-0217-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/statistical errors/type I error
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-width-1335-nl/vufsw-width-1335-nl.Rmd
+++ b/Inferential_Statistics/vufsw-width-1335-nl/vufsw-width-1335-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Probability/vufsw-expectedvalue-0118-nl/vufsw-expectedvalue-0118-nl.Rmd
+++ b/Probability/vufsw-expectedvalue-0118-nl/vufsw-expectedvalue-0118-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Probability/vufsw-expectedvalue-0123-nl/vufsw-expectedvalue-0123-nl.Rmd
+++ b/Probability/vufsw-expectedvalue-0123-nl/vufsw-expectedvalue-0123-nl.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Probability/vufsw-probability-0050-nl/vufsw-probability-0050-nl.Rmd
+++ b/Probability/vufsw-probability-0050-nl/vufsw-probability-0050-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Probability/vufsw-probability-0052-nl/vufsw-probability-0052-nl.Rmd
+++ b/Probability/vufsw-probability-0052-nl/vufsw-probability-0052-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Probability/vufsw-probability-0071-nl/vufsw-probability-0071-nl.Rmd
+++ b/Probability/vufsw-probability-0071-nl/vufsw-probability-0071-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Probability/vufsw-probability-0213-nl/vufsw-probability-0213-nl.Rmd
+++ b/Probability/vufsw-probability-0213-nl/vufsw-probability-0213-nl.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Probability/vufsw-probability-2004-nl/vufsw-probability-2004-nl.Rmd
+++ b/Probability/vufsw-probability-2004-nl/vufsw-probability-2004-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Reliability/vufsw-cronbach's_alpha-1106/vufsw-cronbach's_alpha-1106.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1106/vufsw-cronbach's_alpha-1106.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach's_alpha-1337-nl/vufsw-cronbach's_alpha-1337-nl.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1337-nl/vufsw-cronbach's_alpha-1337-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0025-nl/vufsw-cronbach'salpha-0025-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0025-nl/vufsw-cronbach'salpha-0025-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0026-nl/vufsw-cronbach'salpha-0026-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0026-nl/vufsw-cronbach'salpha-0026-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0044-nl/vufsw-cronbach'salpha-0044-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0044-nl/vufsw-cronbach'salpha-0044-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0051-nl/vufsw-cronbach'salpha-0051-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0051-nl/vufsw-cronbach'salpha-0051-nl.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0070-nl/vufsw-cronbach'salpha-0070-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0070-nl/vufsw-cronbach'salpha-0070-nl.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0090-nl/vufsw-cronbach'salpha-0090-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0090-nl/vufsw-cronbach'salpha-0090-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Reliability/vufsw-cronbach'salpha-1122-nl/vufsw-cronbach'salpha-1122-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-1122-nl/vufsw-cronbach'salpha-1122-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-1186-nl/vufsw-cronbach'salpha-1186-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-1186-nl/vufsw-cronbach'salpha-1186-nl.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Variable-type/vufsw-variable_type-1109-nl/vufsw-variable_type-1109-nl.Rmd
+++ b/Variable-type/vufsw-variable_type-1109-nl/vufsw-variable_type-1109-nl.Rmd
@@ -38,6 +38,6 @@ exshuffle: TRUE
 exsection: variable type
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Variable-type/vufsw-variable_type-1198-nl/vufsw-variable_type-1198-nl.Rmd
+++ b/Variable-type/vufsw-variable_type-1198-nl/vufsw-variable_type-1198-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: variable type
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Variable-type/vufsw-variabletype-0093-nl/vufsw-variabletype-0093-nl.Rmd
+++ b/Variable-type/vufsw-variabletype-0093-nl/vufsw-variabletype-0093-nl.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: variable type
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Variable-type/vufsw-variabletype-0218-nl/vufsw-variabletype-0218-nl.Rmd
+++ b/Variable-type/vufsw-variabletype-0218-nl/vufsw-variabletype-0218-nl.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: variable type
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 


### PR DESCRIPTION
@tasospsy not sure whether this is causing issues, but this is a one time fix for all `exextra[Language]: dutch` in the whole itembank. If this is too riskt, just decline the PR.