### PR TITLE
fix typos in language metadata in Assumptions folder for both English and Dutch

### DIFF
--- a/Assumptions/vufsw-assumptions-0265-nl/vufsw-assumptions-0265-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0265-nl/vufsw-assumptions-0265-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-assumptions-0266-nl/vufsw-assumptions-0266-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0266-nl/vufsw-assumptions-0266-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-assumptions-0280-nl/vufsw-assumptions-0280-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0280-nl/vufsw-assumptions-0280-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-assumptions-0286-nl/vufsw-assumptions-0286-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0286-nl/vufsw-assumptions-0286-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-assumptions-0331-nl/vufsw-assumptions-0331-nl.Rmd
+++ b/Assumptions/vufsw-assumptions-0331-nl/vufsw-assumptions-0331-nl.Rmd
@@ -32,6 +32,6 @@ exshuffle: TRUE
 exsection: Assumptions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-assumptions-1004-en/vufsw-assumptions-1004-en.Rmd
+++ b/Assumptions/vufsw-assumptions-1004-en/vufsw-assumptions-1004-en.Rmd
@@ -73,6 +73,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/assumptions
 exextra[Type]: interpretating graph
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-assumptions-1009-en/vufsw-assumptions-1009-en.Rmd
+++ b/Assumptions/vufsw-assumptions-1009-en/vufsw-assumptions-1009-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/assumptions
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-homogeneityofvariance-0263-en/vufsw-homogeneityofvariance-0263-en.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0263-en/vufsw-homogeneityofvariance-0263-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homogeneityofvariance-0263-nl/vufsw-homogeneityofvariance-0263-nl.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0263-nl/vufsw-homogeneityofvariance-0263-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homogeneityofvariance-0309-nl/vufsw-homogeneityofvariance-0309-nl.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0309-nl/vufsw-homogeneityofvariance-0309-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homogeneityofvariance-0333-nl/vufsw-homogeneityofvariance-0333-nl.Rmd
+++ b/Assumptions/vufsw-homogeneityofvariance-0333-nl/vufsw-homogeneityofvariance-0333-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homoscedasticity-0278-nl/vufsw-homoscedasticity-0278-nl.Rmd
+++ b/Assumptions/vufsw-homoscedasticity-0278-nl/vufsw-homoscedasticity-0278-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: assumptions/homoscedasticity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-homoscedasticity-2108-nl/vufsw-homoscedasticity-2108-nl.Rmd
+++ b/Assumptions/vufsw-homoscedasticity-2108-nl/vufsw-homoscedasticity-2108-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions/homoscedasticity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-levene's_test-1050-en/vufsw-levene's_test-1050-en.Rmd
+++ b/Assumptions/vufsw-levene's_test-1050-en/vufsw-levene's_test-1050-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-levene's_test-1050-nl/vufsw-levene's_test-1050-nl.Rmd
+++ b/Assumptions/vufsw-levene's_test-1050-nl/vufsw-levene's_test-1050-nl.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-levene's_test-1381-nl/vufsw-levene's_test-1381-nl.Rmd
+++ b/Assumptions/vufsw-levene's_test-1381-nl/vufsw-levene's_test-1381-nl.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-levene'stest-0306-nl/vufsw-levene'stest-0306-nl.Rmd
+++ b/Assumptions/vufsw-levene'stest-0306-nl/vufsw-levene'stest-0306-nl.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-levene'stest-0307-nl/vufsw-levene'stest-0307-nl.Rmd
+++ b/Assumptions/vufsw-levene'stest-0307-nl/vufsw-levene'stest-0307-nl.Rmd
@@ -42,6 +42,6 @@ extol: 0
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-levenestest-1288-nl/vufsw-levenestest-1288-nl.Rmd
+++ b/Assumptions/vufsw-levenestest-1288-nl/vufsw-levenestest-1288-nl.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: interpreting output
 exextra[Program]: spss
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-linearity-0279-nl/vufsw-linearity-0279-nl.Rmd
+++ b/Assumptions/vufsw-linearity-0279-nl/vufsw-linearity-0279-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: assumptions/linearity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-multicolinearity-2106-nl/vufsw-multicolinearity-2106-nl.Rmd
+++ b/Assumptions/vufsw-multicolinearity-2106-nl/vufsw-multicolinearity-2106-nl.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: assumptions/multicolinearity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-normality-0276-nl/vufsw-normality-0276-nl.Rmd
+++ b/Assumptions/vufsw-normality-0276-nl/vufsw-normality-0276-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: assumptions/normality
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-normality-0277-nl/vufsw-normality-0277-nl.Rmd
+++ b/Assumptions/vufsw-normality-0277-nl/vufsw-normality-0277-nl.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: assumptions/normality
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-ratio_of_variance-1377-nl/vufsw-ratio_of_variance-1377-nl.Rmd
+++ b/Assumptions/vufsw-ratio_of_variance-1377-nl/vufsw-ratio_of_variance-1377-nl.Rmd
@@ -77,6 +77,6 @@ exshuffle: TRUE
 exsection: assumptions/homogeneity of variance/ratio of variance
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical thinking
 

--- a/Assumptions/vufsw-residualplot-0077-nl/vufsw-residualplot-0077-nl.Rmd
+++ b/Assumptions/vufsw-residualplot-0077-nl/vufsw-residualplot-0077-nl.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: assumptions/homoscedasticity/residual plot
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical reasoning
 

--- a/Assumptions/vufsw-sphericity-0264-nl/vufsw-sphericity-0264-nl.Rmd
+++ b/Assumptions/vufsw-sphericity-0264-nl/vufsw-sphericity-0264-nl.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: assumptions/sphericity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 

--- a/Assumptions/vufsw-sphericity-0310-nl/vufsw-sphericity-0310-nl.Rmd
+++ b/Assumptions/vufsw-sphericity-0310-nl/vufsw-sphericity-0310-nl.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: assumptions/sphericity
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: dutch
+exextra[Language]: Dutch
 exextra[Level]: statistical literacy
 


### PR DESCRIPTION
I checked all items individually and made sure that the exextra[Language] is either "Dutch" or "English"