### PR TITLE
Bugfix/language metadata spelling

### DIFF
--- a/Descriptive-statistics/vufgb-mode-001-en/vufgb-mode-001-en.Rmd
+++ b/Descriptive-statistics/vufgb-mode-001-en/vufgb-mode-001-en.Rmd
@@ -27,5 +27,5 @@ extype: schoice
 exsolution: 0010
 exsection: Descriptive statistics/Summary Statistics/Measures of Location/Mode
 exextra[Type]: Conceptual
-exextra[Language]: Englisch
+exextra[Language]: English
 exextra[Level]: Statistical Literacy

--- a/Descriptive-statistics/vufgb-outliers-001-nl/vufgb-outliers-001-nl.Rmd
+++ b/Descriptive-statistics/vufgb-outliers-001-nl/vufgb-outliers-001-nl.Rmd
@@ -28,5 +28,5 @@ exsolution: 0010
 exsection: Descriptive statistics/Summary Statistics/Outliers
 exextra[Type]: Conceptual, Interpreting output
 exextra[Program]: 
-exextra[Language]: Ducth
+exextra[Language]: Dutch
 exextra[Level]: Statistical Literacy

--- a/Descriptive-statistics/vufsw-correlation-1099-en/vufsw-correlation-1099-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1099-en/vufsw-correlation-1099-en.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1334-en/vufsw-correlation-1334-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1334-en/vufsw-correlation-1334-en.Rmd
@@ -42,6 +42,6 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1336-en/vufsw-correlation-1336-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1336-en/vufsw-correlation-1336-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-1338-en/vufsw-correlation-1338-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1338-en/vufsw-correlation-1338-en.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlation-2000-en/vufsw-correlation-2000-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-2000-en/vufsw-correlation-2000-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Descriptive-statistics/vufsw-correlation-2033-en/vufsw-correlation-2033-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-2033-en/vufsw-correlation-2033-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-correlations-1030-en/vufsw-correlations-1030-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1030-en/vufsw-correlations-1030-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-covariance-1333-en/vufsw-covariance-1333-en.Rmd
+++ b/Descriptive-statistics/vufsw-covariance-1333-en/vufsw-covariance-1333-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/covariance
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-empiricalrule-0008-en/vufsw-empiricalrule-0008-en.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0008-en/vufsw-empiricalrule-0008-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-interquartilerange-1083-en/vufsw-interquartilerange-1083-en.Rmd
+++ b/Descriptive-statistics/vufsw-interquartilerange-1083-en/vufsw-interquartilerange-1083-en.Rmd
@@ -82,6 +82,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/interquartile range/ boxplot
 exextra[Type]: interpretating output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-measures_of_spread-1141-en/vufsw-measures_of_spread-1141-en.Rmd
+++ b/Descriptive-statistics/vufsw-measures_of_spread-1141-en/vufsw-measures_of_spread-1141-en.Rmd
@@ -79,6 +79,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-measures_of_spread-1283-en/vufsw-measures_of_spread-1283-en.Rmd
+++ b/Descriptive-statistics/vufsw-measures_of_spread-1283-en/vufsw-measures_of_spread-1283-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-measures_of_spread-2001-en/vufsw-measures_of_spread-2001-en.Rmd
+++ b/Descriptive-statistics/vufsw-measures_of_spread-2001-en/vufsw-measures_of_spread-2001-en.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-measuresoflocation-1076-en/vufsw-measuresoflocation-1076-en.Rmd
+++ b/Descriptive-statistics/vufsw-measuresoflocation-1076-en/vufsw-measuresoflocation-1076-en.Rmd
@@ -70,6 +70,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of location
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-outliers-1112-en/vufsw-outliers-1112-en.Rmd
+++ b/Descriptive-statistics/vufsw-outliers-1112-en/vufsw-outliers-1112-en.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/outliers
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-proportion-1096-en/vufsw-proportion-1096-en.Rmd
+++ b/Descriptive-statistics/vufsw-proportion-1096-en/vufsw-proportion-1096-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/proportion
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Descriptive-statistics/vufsw-proportion-1279-en/vufsw-proportion-1279-en.Rmd
+++ b/Descriptive-statistics/vufsw-proportion-1279-en/vufsw-proportion-1279-en.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/proportion
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standard_deviation-1077-en/vufsw-standard_deviation-1077-en.Rmd
+++ b/Descriptive-statistics/vufsw-standard_deviation-1077-en/vufsw-standard_deviation-1077-en.Rmd
@@ -31,6 +31,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standard_deviation-1210-en/vufsw-standard_deviation-1210-en.Rmd
+++ b/Descriptive-statistics/vufsw-standard_deviation-1210-en/vufsw-standard_deviation-1210-en.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-standarddeviation-1082-en/vufsw-standarddeviation-1082-en.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-1082-en/vufsw-standarddeviation-1082-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-standarddeviation-1217-en/vufsw-standarddeviation-1217-en.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-1217-en/vufsw-standarddeviation-1217-en.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/measures of spread/standard deviation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-width-1121-en/vufsw-width-1121-en.Rmd
+++ b/Descriptive-statistics/vufsw-width-1121-en/vufsw-width-1121-en.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Descriptive-statistics/vufsw-z-score-1093-en/vufsw-z-score-1093-en.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-1093-en/vufsw-z-score-1093-en.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Descriptive-statistics/vufsw-z-score-1097-en/vufsw-z-score-1097-en.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-1097-en/vufsw-z-score-1097-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-1108-en/vufsw-z-score-1108-en.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-1108-en/vufsw-z-score-1108-en.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: calculation
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-1110-en/vufsw-z-score-1110-en.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-1110-en/vufsw-z-score-1110-en.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Descriptive-statistics/vufsw-z-score-1176-en/vufsw-z-score-1176-en.Rmd
+++ b/Descriptive-statistics/vufsw-z-score-1176-en/vufsw-z-score-1176-en.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Descriptive-statistics/vufsw-zscore-1084-en/vufsw-zscore-1084-en.Rmd
+++ b/Descriptive-statistics/vufsw-zscore-1084-en/vufsw-zscore-1084-en.Rmd
@@ -167,6 +167,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/score interpretation/z-score
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Distributions/vufsw-central_limit_theorem-1153-en/vufsw-central_limit_theorem-1153-en.Rmd
+++ b/Distributions/vufsw-central_limit_theorem-1153-en/vufsw-central_limit_theorem-1153-en.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: distributions/limit theorems/central limit theorem
 exextra[Type]: calculation
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Distributions/vufsw-normal-1075-en/vufsw-normal-1075-en.Rmd
+++ b/Distributions/vufsw-normal-1075-en/vufsw-normal-1075-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Distributions/vufsw-normal-1081-en/vufsw-normal-1081-en.Rmd
+++ b/Distributions/vufsw-normal-1081-en/vufsw-normal-1081-en.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Distributions/vufsw-normal-1105-en/vufsw-normal-1105-en.Rmd
+++ b/Distributions/vufsw-normal-1105-en/vufsw-normal-1105-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: distributions/continuous/normal
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Factor-analysis/vufsw-explained_variance-2110-en/vufsw-explained_variance-2110-en.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2110-en/vufsw-explained_variance-2110-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]: interpreting output 
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-explained_variance-2113-en/vufsw-explained_variance-2113-en.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2113-en/vufsw-explained_variance-2113-en.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]:  Interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-explained_variance-2114-en/vufsw-explained_variance-2114-en.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2114-en/vufsw-explained_variance-2114-en.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Factor-analysis/vufsw-scree_plot-1290-en/vufsw-scree_plot-1290-en.Rmd
+++ b/Factor-analysis/vufsw-scree_plot-1290-en/vufsw-scree_plot-1290-en.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: factor analysis/scree plot
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/uu-Null-hypothesis-806-nl/uu-Null-hypothesis-806-nl.Rmd
+++ b/Inferential_Statistics/uu-Null-hypothesis-806-nl/uu-Null-hypothesis-806-nl.Rmd
@@ -29,5 +29,5 @@ extype: schoice
 exsolution: 0010
 exsection: Inferential Statistics/NHST/Hypothesis/Null hypothesis
 exextra[Type]: Conceptual
-exextra[Language]:Dutch 
+exextra[Language]: Dutch
 exextra[Level]: Statistical Literacy 

--- a/Inferential_Statistics/vufgb-anova-005-en/vufgb-anova-005-en.Rmd
+++ b/Inferential_Statistics/vufgb-anova-005-en/vufgb-anova-005-en.Rmd
@@ -35,5 +35,5 @@ exsolution: 0001
 exsection: Inferential Statistics/Parametric Techniques/ANOVA, Descriptive statistics/Data representation/Graphs/Venn diagram
 exextra[Type]: Interpreting graph, Conceptual
 exextra[Program]: 
-exextra[Language]: Englishh
+exextra[Language]: English
 exextra[Level]: Statistical Literacy

--- a/Inferential_Statistics/vufgb-cohensd-002-nl/vufgb-cohensd-002-nl.Rmd
+++ b/Inferential_Statistics/vufgb-cohensd-002-nl/vufgb-cohensd-002-nl.Rmd
@@ -28,5 +28,5 @@ exsolution: 1000
 exsection: Inferential Statistics/Effect size/Cohen's d, Inferential Statistics/Effect size
 exextra[Type]: 
 exextra[Program]: 
-exextra[Language]: Calculation
+exextra[Language]: Dutch
 exextra[Level]: Statistical Literacy

--- a/Inferential_Statistics/vufgb-equation-013-nl/vufgb-equation-013-nl.Rmd
+++ b/Inferential_Statistics/vufgb-equation-013-nl/vufgb-equation-013-nl.Rmd
@@ -34,5 +34,5 @@ exsolution: 0001
 exsection: Inferential Statistics/Regression/Equation
 exextra[Type]: Interpreting output
 exextra[Program]: 
-exextra[Language]:Dutch 
+exextra[Language]: Dutch
 exextra[Level]: Statistical Thinking

--- a/Inferential_Statistics/vufgb-mediation-013-nl/vufgb-mediation-013-nl.Rmd
+++ b/Inferential_Statistics/vufgb-mediation-013-nl/vufgb-mediation-013-nl.Rmd
@@ -28,5 +28,5 @@ exsolution: 1000
 exsection: Inferential Statistics/Regression/Multiple linear regression/Mediation
 exextra[Type]: Conceptual, Interpreting output
 exextra[Program]: 
-exextra[Language]: Duthc
+exextra[Language]: Dutch
 exextra[Level]: Statistical Literacy

--- a/Inferential_Statistics/vufgb-twowayanova-020-nl/vufgb-twowayanova-020-nl.Rmd
+++ b/Inferential_Statistics/vufgb-twowayanova-020-nl/vufgb-twowayanova-020-nl.Rmd
@@ -28,5 +28,5 @@ exsolution: 0100
 exsection: Inferential Statistics/Parametric Techniques/ANOVA/Twoway ANOVA
 exextra[Type]: Test choice
 exextra[Program]: 
-exextra[Language]: Ducth
+exextra[Language]: Dutch
 exextra[Level]: Statistical Thinking

--- a/Inferential_Statistics/vufsw-alternative_hypothesis-1278-en/vufsw-alternative_hypothesis-1278-en.Rmd
+++ b/Inferential_Statistics/vufsw-alternative_hypothesis-1278-en/vufsw-alternative_hypothesis-1278-en.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/alternative hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-analysis-1213-en/vufsw-analysis-1213-en.Rmd
+++ b/Inferential_Statistics/vufsw-analysis-1213-en/vufsw-analysis-1213-en.Rmd
@@ -38,7 +38,7 @@ exshuffle: TRUE
 exsection: reliability/analysis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -47,7 +47,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-ancova-0252-en/vufsw-ancova-0252-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0252-en/vufsw-ancova-0252-en.Rmd
@@ -39,7 +39,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -48,7 +48,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-ancova-0253-en/vufsw-ancova-0253-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0253-en/vufsw-ancova-0253-en.Rmd
@@ -43,7 +43,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -52,7 +52,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical reasoning

--- a/Inferential_Statistics/vufsw-ancova-0254-en/vufsw-ancova-0254-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0254-en/vufsw-ancova-0254-en.Rmd
@@ -36,7 +36,7 @@ extol: 0.00499999999999989
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -45,7 +45,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical reasoning

--- a/Inferential_Statistics/vufsw-ancova-0273-en/vufsw-ancova-0273-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0273-en/vufsw-ancova-0273-en.Rmd
@@ -48,7 +48,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -57,7 +57,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical reasoning

--- a/Inferential_Statistics/vufsw-ancova-2069-en/vufsw-ancova-2069-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2069-en/vufsw-ancova-2069-en.Rmd
@@ -61,7 +61,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -70,7 +70,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-ancova-2070-en/vufsw-ancova-2070-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2070-en/vufsw-ancova-2070-en.Rmd
@@ -58,7 +58,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -67,7 +67,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-ancova-2071-en/vufsw-ancova-2071-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2071-en/vufsw-ancova-2071-en.Rmd
@@ -60,7 +60,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -69,7 +69,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical reasoning

--- a/Inferential_Statistics/vufsw-ancova-2075-en/vufsw-ancova-2075-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2075-en/vufsw-ancova-2075-en.Rmd
@@ -62,7 +62,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/ancova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -71,7 +71,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-anova_f-test-1100-en/vufsw-anova_f-test-1100-en.Rmd
+++ b/Inferential_Statistics/vufsw-anova_f-test-1100-en/vufsw-anova_f-test-1100-en.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/anova f-test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-anovaftest-1010-en/vufsw-anovaftest-1010-en.Rmd
+++ b/Inferential_Statistics/vufsw-anovaftest-1010-en/vufsw-anovaftest-1010-en.Rmd
@@ -50,6 +50,6 @@ extol: 0.01
 exsection: inferential statistics/parametric techniques/anova/anova f-test
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical analysis
 

--- a/Inferential_Statistics/vufsw-chi-squared-1129-en/vufsw-chi-squared-1129-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1129-en/vufsw-chi-squared-1129-en.Rmd
@@ -128,6 +128,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1132-en/vufsw-chi-squared-1132-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1132-en/vufsw-chi-squared-1132-en.Rmd
@@ -111,6 +111,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1133-en/vufsw-chi-squared-1133-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1133-en/vufsw-chi-squared-1133-en.Rmd
@@ -111,6 +111,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1149-en/vufsw-chi-squared-1149-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1149-en/vufsw-chi-squared-1149-en.Rmd
@@ -104,6 +104,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1158-en/vufsw-chi-squared-1158-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1158-en/vufsw-chi-squared-1158-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1166-en/vufsw-chi-squared-1166-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1166-en/vufsw-chi-squared-1166-en.Rmd
@@ -128,6 +128,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1218-en/vufsw-chi-squared-1218-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1218-en/vufsw-chi-squared-1218-en.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chi-squared-1219-en/vufsw-chi-squared-1219-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared-1219-en/vufsw-chi-squared-1219-en.Rmd
@@ -97,6 +97,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-chi-squared_for_independence-1262-en/vufsw-chi-squared_for_independence-1262-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared_for_independence-1262-en/vufsw-chi-squared_for_independence-1262-en.Rmd
@@ -91,6 +91,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-chisquared-1203-en/vufsw-chisquared-1203-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-1203-en/vufsw-chisquared-1203-en.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/chi-squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0045-en/vufsw-chisquaredforindependence-0045-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0045-en/vufsw-chisquaredforindependence-0045-en.Rmd
@@ -59,7 +59,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -68,7 +68,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0086-en/vufsw-chisquaredforindependence-0086-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0086-en/vufsw-chisquaredforindependence-0086-en.Rmd
@@ -44,7 +44,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -53,7 +53,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0168-en/vufsw-chisquaredforindependence-0168-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0168-en/vufsw-chisquaredforindependence-0168-en.Rmd
@@ -57,7 +57,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -66,7 +66,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical thinking

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0186-en/vufsw-chisquaredforindependence-0186-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0186-en/vufsw-chisquaredforindependence-0186-en.Rmd
@@ -54,7 +54,7 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables/chi-squared for independence
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -63,7 +63,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical reasoning

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1301-en/vufsw-coefficient_t-test-1301-en.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1301-en/vufsw-coefficient_t-test-1301-en.Rmd
@@ -50,7 +50,7 @@ extol: 0
 exsection: inferential statistics/regression/coefficient t-test
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -59,7 +59,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1353-en/vufsw-coefficient_t-test-1353-en.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1353-en/vufsw-coefficient_t-test-1353-en.Rmd
@@ -51,7 +51,7 @@ extol: 0
 exsection: inferential statistics/regression/coefficient t-test
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -60,7 +60,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-conditional_probability-1086-en/vufsw-conditional_probability-1086-en.Rmd
+++ b/Inferential_Statistics/vufsw-conditional_probability-1086-en/vufsw-conditional_probability-1086-en.Rmd
@@ -98,6 +98,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/conditional probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_interval-1280-en/vufsw-confidence_interval-1280-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_interval-1280-en/vufsw-confidence_interval-1280-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/confidence interval
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1128-en/vufsw-confidence_intervals-1128-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1128-en/vufsw-confidence_intervals-1128-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1168-en/vufsw-confidence_intervals-1168-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1168-en/vufsw-confidence_intervals-1168-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1239-en/vufsw-confidence_intervals-1239-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1239-en/vufsw-confidence_intervals-1239-en.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1246-en/vufsw-confidence_intervals-1246-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1246-en/vufsw-confidence_intervals-1246-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1253-en/vufsw-confidence_intervals-1253-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1253-en/vufsw-confidence_intervals-1253-en.Rmd
@@ -36,6 +36,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1260-en/vufsw-confidence_intervals-1260-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1260-en/vufsw-confidence_intervals-1260-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1270-en/vufsw-confidence_intervals-1270-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1270-en/vufsw-confidence_intervals-1270-en.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_intervals-1339-en/vufsw-confidence_intervals-1339-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1339-en/vufsw-confidence_intervals-1339-en.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidence_level-1120-en/vufsw-confidence_level-1120-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_level-1120-en/vufsw-confidence_level-1120-en.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/confidence level
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceinterval-1240-en/vufsw-confidenceinterval-1240-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceinterval-1240-en/vufsw-confidenceinterval-1240-en.Rmd
@@ -80,6 +80,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/confidence interval
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0038-en/vufsw-confidenceintervals-0038-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0038-en/vufsw-confidenceintervals-0038-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0043-en/vufsw-confidenceintervals-0043-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0043-en/vufsw-confidenceintervals-0043-en.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-0104-en/vufsw-confidenceintervals-0104-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0104-en/vufsw-confidenceintervals-0104-en.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-confidenceintervals-1178-en/vufsw-confidenceintervals-1178-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-1178-en/vufsw-confidenceintervals-1178-en.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-confidencelevel-1180-en/vufsw-confidencelevel-1180-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidencelevel-1180-en/vufsw-confidencelevel-1180-en.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/confidence level
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-correlation-0132-en/vufsw-correlation-0132-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-0132-en/vufsw-correlation-0132-en.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-correlation-1200-en/vufsw-correlation-1200-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1200-en/vufsw-correlation-1200-en.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-correlation-1294-en/vufsw-correlation-1294-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1294-en/vufsw-correlation-1294-en.Rmd
@@ -43,6 +43,6 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-correlation-1351-en/vufsw-correlation-1351-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1351-en/vufsw-correlation-1351-en.Rmd
@@ -66,7 +66,7 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: Meta-information
+exextra[Language]: English-information
 ================
 exname: vufsw-correlation-1294-en
 extype: num
@@ -75,7 +75,7 @@ extol: 0
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 
 exextra[Level]: statistical literacy

--- a/Inferential_Statistics/vufsw-correlation-1352-en/vufsw-correlation-1352-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1352-en/vufsw-correlation-1352-en.Rmd
@@ -69,6 +69,6 @@ exshuffle: TRUE
 exsection: descriptive statistics/summary statistics/bivariate statistics/correlation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-correlations-1296-en/vufsw-correlations-1296-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlations-1296-en/vufsw-correlations-1296-en.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/correlations
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-critical_value-1175-en/vufsw-critical_value-1175-en.Rmd
+++ b/Inferential_Statistics/vufsw-critical_value-1175-en/vufsw-critical_value-1175-en.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-critical_value-1276-en/vufsw-critical_value-1276-en.Rmd
+++ b/Inferential_Statistics/vufsw-critical_value-1276-en/vufsw-critical_value-1276-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/significance level/critical value
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-cross_tables-1235-en/vufsw-cross_tables-1235-en.Rmd
+++ b/Inferential_Statistics/vufsw-cross_tables-1235-en/vufsw-cross_tables-1235-en.Rmd
@@ -125,6 +125,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-cross_tables-1256-en/vufsw-cross_tables-1256-en.Rmd
+++ b/Inferential_Statistics/vufsw-cross_tables-1256-en/vufsw-cross_tables-1256-en.Rmd
@@ -77,6 +77,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-crosstables-0002-en/vufsw-crosstables-0002-en.Rmd
+++ b/Inferential_Statistics/vufsw-crosstables-0002-en/vufsw-crosstables-0002-en.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/cross tables
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-equation-0041-en/vufsw-equation-0041-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0041-en/vufsw-equation-0041-en.Rmd
@@ -65,6 +65,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: calculation
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-0157-en/vufsw-equation-0157-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0157-en/vufsw-equation-0157-en.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1007-en/vufsw-equation-1007-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1007-en/vufsw-equation-1007-en.Rmd
@@ -36,6 +36,6 @@ extol: 0
 exsection: inferential statistics/regression/equation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1022-en/vufsw-equation-1022-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1022-en/vufsw-equation-1022-en.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1023-en/vufsw-equation-1023-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1023-en/vufsw-equation-1023-en.Rmd
@@ -39,6 +39,6 @@ extol: 0
 exsection: inferential statistics/regression/equation
 exextra[Type]: performing analysis
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1026-en/vufsw-equation-1026-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1026-en/vufsw-equation-1026-en.Rmd
@@ -81,6 +81,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1090-en/vufsw-equation-1090-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1090-en/vufsw-equation-1090-en.Rmd
@@ -91,6 +91,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1095-en/vufsw-equation-1095-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1095-en/vufsw-equation-1095-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: interpreting graph
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1236-en/vufsw-equation-1236-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1236-en/vufsw-equation-1236-en.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-equation-1282-en/vufsw-equation-1282-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1282-en/vufsw-equation-1282-en.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/equation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-expectedvalue-0118-en/vufsw-expectedvalue-0118-en.Rmd
+++ b/Inferential_Statistics/vufsw-expectedvalue-0118-en/vufsw-expectedvalue-0118-en.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-expectedvalue-0123-en/vufsw-expectedvalue-0123-en.Rmd
+++ b/Inferential_Statistics/vufsw-expectedvalue-0123-en/vufsw-expectedvalue-0123-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-expectedvalue-1257-en/vufsw-expectedvalue-1257-en.Rmd
+++ b/Inferential_Statistics/vufsw-expectedvalue-1257-en/vufsw-expectedvalue-1257-en.Rmd
@@ -104,6 +104,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-explainedvariance-0170-en/vufsw-explainedvariance-0170-en.Rmd
+++ b/Inferential_Statistics/vufsw-explainedvariance-0170-en/vufsw-explainedvariance-0170-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: factor analysis/explained variance
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-f-test_for_comparing_nested_models-1268-en/vufsw-f-test_for_comparing_nested_models-1268-en.Rmd
+++ b/Inferential_Statistics/vufsw-f-test_for_comparing_nested_models-1268-en/vufsw-f-test_for_comparing_nested_models-1268-en.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/f-test for comparing (nested) models
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-hypothesis-1185-en/vufsw-hypothesis-1185-en.Rmd
+++ b/Inferential_Statistics/vufsw-hypothesis-1185-en/vufsw-hypothesis-1185-en.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-independent_events-1267-en/vufsw-independent_events-1267-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_events-1267-en/vufsw-independent_events-1267-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/general rules/independent events
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independent_samples_mean-1220-en/vufsw-independent_samples_mean-1220-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_mean-1220-en/vufsw-independent_samples_mean-1220-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric rechniques/t-test/independent samples means
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1145-en/vufsw-independent_samples_means-1145-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1145-en/vufsw-independent_samples_means-1145-en.Rmd
@@ -92,6 +92,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1162-en/vufsw-independent_samples_means-1162-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1162-en/vufsw-independent_samples_means-1162-en.Rmd
@@ -91,6 +91,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1232-en/vufsw-independent_samples_means-1232-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1232-en/vufsw-independent_samples_means-1232-en.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1243-en/vufsw-independent_samples_means-1243-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1243-en/vufsw-independent_samples_means-1243-en.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independent_samples_means-1249-en/vufsw-independent_samples_means-1249-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1249-en/vufsw-independent_samples_means-1249-en.Rmd
@@ -99,6 +99,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-independentsamplesmeans-1174-en/vufsw-independentsamplesmeans-1174-en.Rmd
+++ b/Inferential_Statistics/vufsw-independentsamplesmeans-1174-en/vufsw-independentsamplesmeans-1174-en.Rmd
@@ -75,6 +75,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/independent samples means
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-levene'stest-0307-en/vufsw-levene'stest-0307-en.Rmd
+++ b/Inferential_Statistics/vufsw-levene'stest-0307-en/vufsw-levene'stest-0307-en.Rmd
@@ -43,6 +43,6 @@ extol: 0
 exsection: assumptions/homogeneity of variance/levene's test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-0288-en/vufsw-manova-0288-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0288-en/vufsw-manova-0288-en.Rmd
@@ -43,6 +43,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1040-en/vufsw-manova-1040-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1040-en/vufsw-manova-1040-en.Rmd
@@ -64,6 +64,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: performing analysis
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-manova-1041-en/vufsw-manova-1041-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1041-en/vufsw-manova-1041-en.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1042-en/vufsw-manova-1042-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1042-en/vufsw-manova-1042-en.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1043-en/vufsw-manova-1043-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1043-en/vufsw-manova-1043-en.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1046-en/vufsw-manova-1046-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1046-en/vufsw-manova-1046-en.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1047-en/vufsw-manova-1047-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1047-en/vufsw-manova-1047-en.Rmd
@@ -39,6 +39,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1067-en/vufsw-manova-1067-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1067-en/vufsw-manova-1067-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-manova-1070-en/vufsw-manova-1070-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1070-en/vufsw-manova-1070-en.Rmd
@@ -36,6 +36,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: englsh
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-manova-1073-en/vufsw-manova-1073-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1073-en/vufsw-manova-1073-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/manova
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-marginoferror-1163-en/vufsw-marginoferror-1163-en.Rmd
+++ b/Inferential_Statistics/vufsw-marginoferror-1163-en/vufsw-marginoferror-1163-en.Rmd
@@ -85,6 +85,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/margin of error
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-0292-en/vufsw-mediation-0292-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0292-en/vufsw-mediation-0292-en.Rmd
@@ -35,6 +35,6 @@ extol: 0.01
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-1033-en/vufsw-mediation-1033-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1033-en/vufsw-mediation-1033-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mediation-1314-en/vufsw-mediation-1314-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1314-en/vufsw-mediation-1314-en.Rmd
@@ -63,6 +63,6 @@ extol: 0.200000000000003
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1315-en/vufsw-mediation-1315-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1315-en/vufsw-mediation-1315-en.Rmd
@@ -62,6 +62,6 @@ extol: 0.001
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1366-en/vufsw-mediation-1366-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1366-en/vufsw-mediation-1366-en.Rmd
@@ -53,6 +53,6 @@ extol: 0.300000000000001
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mediation-1367-en/vufsw-mediation-1367-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1367-en/vufsw-mediation-1367-en.Rmd
@@ -55,6 +55,6 @@ extol: 0.001
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mediation-3034-en/vufsw-mediation-3034-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-3034-en/vufsw-mediation-3034-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/mediation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1058-en/vufsw-mixed_design_anova-1058-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1058-en/vufsw-mixed_design_anova-1058-en.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1059-en/vufsw-mixed_design_anova-1059-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1059-en/vufsw-mixed_design_anova-1059-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1060-en/vufsw-mixed_design_anova-1060-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1060-en/vufsw-mixed_design_anova-1060-en.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1061-en/vufsw-mixed_design_anova-1061-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1061-en/vufsw-mixed_design_anova-1061-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1062-en/vufsw-mixed_design_anova-1062-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1062-en/vufsw-mixed_design_anova-1062-en.Rmd
@@ -76,6 +76,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpreting out
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1064-en/vufsw-mixed_design_anova-1064-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1064-en/vufsw-mixed_design_anova-1064-en.Rmd
@@ -60,6 +60,6 @@ extol: 0.000399999999999998
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpreting out
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1065-en/vufsw-mixed_design_anova-1065-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1065-en/vufsw-mixed_design_anova-1065-en.Rmd
@@ -55,6 +55,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpreting out
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1074-en/vufsw-mixed_design_anova-1074-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1074-en/vufsw-mixed_design_anova-1074-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0249-en/vufsw-mixeddesignanova-0249-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0249-en/vufsw-mixeddesignanova-0249-en.Rmd
@@ -62,6 +62,6 @@ extol: 5e-04
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0250-en/vufsw-mixeddesignanova-0250-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0250-en/vufsw-mixeddesignanova-0250-en.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0251-en/vufsw-mixeddesignanova-0251-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0251-en/vufsw-mixeddesignanova-0251-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0308-en/vufsw-mixeddesignanova-0308-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0308-en/vufsw-mixeddesignanova-0308-en.Rmd
@@ -43,6 +43,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0337-en/vufsw-mixeddesignanova-0337-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0337-en/vufsw-mixeddesignanova-0337-en.Rmd
@@ -44,6 +44,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/mixed design anova
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0311-en/vufsw-moderation-0311-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0311-en/vufsw-moderation-0311-en.Rmd
@@ -45,6 +45,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-0312-en/vufsw-moderation-0312-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0312-en/vufsw-moderation-0312-en.Rmd
@@ -44,6 +44,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-1020-en/vufsw-moderation-1020-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1020-en/vufsw-moderation-1020-en.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1021-en/vufsw-moderation-1021-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1021-en/vufsw-moderation-1021-en.Rmd
@@ -37,6 +37,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-moderation-1274-en/vufsw-moderation-1274-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1274-en/vufsw-moderation-1274-en.Rmd
@@ -76,6 +76,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-moderation-1305-en/vufsw-moderation-1305-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1305-en/vufsw-moderation-1305-en.Rmd
@@ -53,6 +53,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/moderation
 exextra[Type]: interpreting output
 exextra[Program]: calculation
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1207-en/vufsw-multiple_linear_regression-1207-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1207-en/vufsw-multiple_linear_regression-1207-en.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1211-en/vufsw-multiple_linear_regression-1211-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1211-en/vufsw-multiple_linear_regression-1211-en.Rmd
@@ -43,6 +43,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1215-en/vufsw-multiple_linear_regression-1215-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1215-en/vufsw-multiple_linear_regression-1215-en.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1227-en/vufsw-multiple_linear_regression-1227-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1227-en/vufsw-multiple_linear_regression-1227-en.Rmd
@@ -169,6 +169,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1237-en/vufsw-multiple_linear_regression-1237-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1237-en/vufsw-multiple_linear_regression-1237-en.Rmd
@@ -115,6 +115,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1264-en/vufsw-multiple_linear_regression-1264-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1264-en/vufsw-multiple_linear_regression-1264-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-multiplelinearregression-1002-en/vufsw-multiplelinearregression-1002-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-1002-en/vufsw-multiplelinearregression-1002-en.Rmd
@@ -79,6 +79,6 @@ exshuffle: TRUE
 exsection: Inferential Statistics/Regression/Multiple linear regression
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-multiplelinearregression-1003-en/vufsw-multiplelinearregression-1003-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-1003-en/vufsw-multiplelinearregression-1003-en.Rmd
@@ -88,6 +88,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/multiple linear regression
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-null_hypothesis-1146-en/vufsw-null_hypothesis-1146-en.Rmd
+++ b/Inferential_Statistics/vufsw-null_hypothesis-1146-en/vufsw-null_hypothesis-1146-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/null hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-null_hypothesis-1172-en/vufsw-null_hypothesis-1172-en.Rmd
+++ b/Inferential_Statistics/vufsw-null_hypothesis-1172-en/vufsw-null_hypothesis-1172-en.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/null hypothesis
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-one_sample_mean-1085-en/vufsw-one_sample_mean-1085-en.Rmd
+++ b/Inferential_Statistics/vufsw-one_sample_mean-1085-en/vufsw-one_sample_mean-1085-en.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/z-test/one sample mean
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-one_sample_mean-1157-en/vufsw-one_sample_mean-1157-en.Rmd
+++ b/Inferential_Statistics/vufsw-one_sample_mean-1157-en/vufsw-one_sample_mean-1157-en.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/one sample mean
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-one_sample_mean-1160-en/vufsw-one_sample_mean-1160-en.Rmd
+++ b/Inferential_Statistics/vufsw-one_sample_mean-1160-en/vufsw-one_sample_mean-1160-en.Rmd
@@ -49,6 +49,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/one sample mean
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-one_sample_mean-1171-en/vufsw-one_sample_mean-1171-en.Rmd
+++ b/Inferential_Statistics/vufsw-one_sample_mean-1171-en/vufsw-one_sample_mean-1171-en.Rmd
@@ -62,6 +62,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/one sample mean
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-one_sample_mean-1242-en/vufsw-one_sample_mean-1242-en.Rmd
+++ b/Inferential_Statistics/vufsw-one_sample_mean-1242-en/vufsw-one_sample_mean-1242-en.Rmd
@@ -67,6 +67,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/one sample mean
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-onesidedhypothesis-1167-en/vufsw-onesidedhypothesis-1167-en.Rmd
+++ b/Inferential_Statistics/vufsw-onesidedhypothesis-1167-en/vufsw-onesidedhypothesis-1167-en.Rmd
@@ -88,6 +88,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/hypothesis/one sided hypothesis
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0255-en/vufsw-onewayanova-0255-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0255-en/vufsw-onewayanova-0255-en.Rmd
@@ -76,6 +76,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0257-en/vufsw-onewayanova-0257-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0257-en/vufsw-onewayanova-0257-en.Rmd
@@ -106,6 +106,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayanova-0345-en/vufsw-onewayanova-0345-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0345-en/vufsw-onewayanova-0345-en.Rmd
@@ -35,6 +35,6 @@ extol: 0.0999999999999996
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-onewayanova-1247-en/vufsw-onewayanova-1247-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1247-en/vufsw-onewayanova-1247-en.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/anova/oneway anova
 exextra[Type]: interpretating output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0334-en/vufsw-onewayrepeatedmeasuresanova-0334-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayrepeatedmeasuresanova-0334-en/vufsw-onewayrepeatedmeasuresanova-0334-en.Rmd
@@ -27,6 +27,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/anova/oneway repeated measures anova
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-paired_samples-1130-en/vufsw-paired_samples-1130-en.Rmd
+++ b/Inferential_Statistics/vufsw-paired_samples-1130-en/vufsw-paired_samples-1130-en.Rmd
@@ -93,6 +93,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/paired samples
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-paired_samples-1131-en/vufsw-paired_samples-1131-en.Rmd
+++ b/Inferential_Statistics/vufsw-paired_samples-1131-en/vufsw-paired_samples-1131-en.Rmd
@@ -87,6 +87,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/paired samples
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-paired_samples-1147-en/vufsw-paired_samples-1147-en.Rmd
+++ b/Inferential_Statistics/vufsw-paired_samples-1147-en/vufsw-paired_samples-1147-en.Rmd
@@ -71,6 +71,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/paired samples
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-paired_samples-1164-en/vufsw-paired_samples-1164-en.Rmd
+++ b/Inferential_Statistics/vufsw-paired_samples-1164-en/vufsw-paired_samples-1164-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/paired samples
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-paired_samples-1275-en/vufsw-paired_samples-1275-en.Rmd
+++ b/Inferential_Statistics/vufsw-paired_samples-1275-en/vufsw-paired_samples-1275-en.Rmd
@@ -178,6 +178,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test/paired samples
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-pairedsamples-0141-nl/vufsw-pairedsamples-0141-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pairedsamples-0141-nl/vufsw-pairedsamples-0141-nl.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t test/paired samples
 exextra[Type]: test choice,na
 exextra[Program]: dutch
-exextra[Language]: statistical reasoning
+exextra[Language]: Dutch
 exextra[Level]: NA
 

--- a/Inferential_Statistics/vufsw-pearson-1332-en/vufsw-pearson-1332-en.Rmd
+++ b/Inferential_Statistics/vufsw-pearson-1332-en/vufsw-pearson-1332-en.Rmd
@@ -39,6 +39,6 @@ extol: 0
 exsection: inferential statistics/parametric techniques/correlations/pearson
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-pvalue-1184-en/vufsw-pvalue-1184-en.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-1184-en/vufsw-pvalue-1184-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/p-value
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-r_squared-1238-en/vufsw-r_squared-1238-en.Rmd
+++ b/Inferential_Statistics/vufsw-r_squared-1238-en/vufsw-r_squared-1238-en.Rmd
@@ -93,6 +93,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-regression-1092-en/vufsw-regression-1092-en.Rmd
+++ b/Inferential_Statistics/vufsw-regression-1092-en/vufsw-regression-1092-en.Rmd
@@ -60,6 +60,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-regression-1222-en/vufsw-regression-1222-en.Rmd
+++ b/Inferential_Statistics/vufsw-regression-1222-en/vufsw-regression-1222-en.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-regression-1255-en/vufsw-regression-1255-en.Rmd
+++ b/Inferential_Statistics/vufsw-regression-1255-en/vufsw-regression-1255-en.Rmd
@@ -47,6 +47,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-residuals-1089-en/vufsw-residuals-1089-en.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-1089-en/vufsw-residuals-1089-en.Rmd
@@ -33,6 +33,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/residuals
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquared-1139-en/vufsw-rsquared-1139-en.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-1139-en/vufsw-rsquared-1139-en.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/r squared
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-rsquaredchange-1001-en/vufsw-rsquaredchange-1001-en.Rmd
+++ b/Inferential_Statistics/vufsw-rsquaredchange-1001-en/vufsw-rsquaredchange-1001-en.Rmd
@@ -51,6 +51,6 @@ extol: 0
 exsection: inferential statistics/regression/multiple linear regression/r squared change
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-sample_proportion-1179-en/vufsw-sample_proportion-1179-en.Rmd
+++ b/Inferential_Statistics/vufsw-sample_proportion-1179-en/vufsw-sample_proportion-1179-en.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: inferential statistics/sampling distributions/sample proportion
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-sampling_distributions-1116-en/vufsw-sampling_distributions-1116-en.Rmd
+++ b/Inferential_Statistics/vufsw-sampling_distributions-1116-en/vufsw-sampling_distributions-1116-en.Rmd
@@ -41,6 +41,6 @@ exshuffle: TRUE
 exsection: inferential statistics/sampling distributions
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-simple_linear_regression-1143/vufsw-simple_linear_regression-1143.Rmd
+++ b/Inferential_Statistics/vufsw-simple_linear_regression-1143/vufsw-simple_linear_regression-1143.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-simple_linear_regression-1209-en/vufsw-simple_linear_regression-1209-en.Rmd
+++ b/Inferential_Statistics/vufsw-simple_linear_regression-1209-en/vufsw-simple_linear_regression-1209-en.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-simple_linear_regression-1258-en/vufsw-simple_linear_regression-1258-en.Rmd
+++ b/Inferential_Statistics/vufsw-simple_linear_regression-1258-en/vufsw-simple_linear_regression-1258-en.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-1005-en/vufsw-simplelinearregression-1005-en.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-1005-en/vufsw-simplelinearregression-1005-en.Rmd
@@ -59,6 +59,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-simplelinearregression-1216-en/vufsw-simplelinearregression-1216-en.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-1216-en/vufsw-simplelinearregression-1216-en.Rmd
@@ -44,6 +44,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/simple linear regression
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1094-en/vufsw-slope-1094-en.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1094-en/vufsw-slope-1094-en.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1137-en/vufsw-slope-1137-en.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1137-en/vufsw-slope-1137-en.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1272-en/vufsw-slope-1272-en.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1272-en/vufsw-slope-1272-en.Rmd
@@ -68,6 +68,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: interpretating output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-slope-1273-en/vufsw-slope-1273-en.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1273-en/vufsw-slope-1273-en.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/slope
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-standardized_coefficient-1138-en/vufsw-standardized_coefficient-1138-en.Rmd
+++ b/Inferential_Statistics/vufsw-standardized_coefficient-1138-en/vufsw-standardized_coefficient-1138-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standardized coefficient
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-standardized_coefficient-1208-en/vufsw-standardized_coefficient-1208-en.Rmd
+++ b/Inferential_Statistics/vufsw-standardized_coefficient-1208-en/vufsw-standardized_coefficient-1208-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standardized coefficient
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-standardized_coefficient-1230-en/vufsw-standardized_coefficient-1230-en.Rmd
+++ b/Inferential_Statistics/vufsw-standardized_coefficient-1230-en/vufsw-standardized_coefficient-1230-en.Rmd
@@ -46,6 +46,6 @@ exshuffle: TRUE
 exsection: inferential statistics/regression/standardized coefficient
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-statistical_errors-1126-en/vufsw-statistical_errors-1126-en.Rmd
+++ b/Inferential_Statistics/vufsw-statistical_errors-1126-en/vufsw-statistical_errors-1126-en.Rmd
@@ -86,6 +86,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/statistical errors
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-statistical_errors-1244-en/vufsw-statistical_errors-1244-en.Rmd
+++ b/Inferential_Statistics/vufsw-statistical_errors-1244-en/vufsw-statistical_errors-1244-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/statistical errors
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-sum_of_squares-1053-en/vufsw-sum_of_squares-1053-en.Rmd
+++ b/Inferential_Statistics/vufsw-sum_of_squares-1053-en/vufsw-sum_of_squares-1053-en.Rmd
@@ -93,6 +93,6 @@ extol: 0
 exsection: inferential statistics/regression/sum of squares
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-t-statistic-1127-en/vufsw-t-statistic-1127-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-statistic-1127-en/vufsw-t-statistic-1127-en.Rmd
@@ -110,6 +110,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t-statistic
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-t-statistic-1135-en/vufsw-t-statistic-1135-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-statistic-1135-en/vufsw-t-statistic-1135-en.Rmd
@@ -82,6 +82,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/rest statistic/t-statistic
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-t-statistic-1144-en/vufsw-t-statistic-1144-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-statistic-1144-en/vufsw-t-statistic-1144-en.Rmd
@@ -66,6 +66,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t-statistic
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-t-statistic-1165-en/vufsw-t-statistic-1165-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-statistic-1165-en/vufsw-t-statistic-1165-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t-statistic
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-t-statistic-1265-en/vufsw-t-statistic-1265-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-statistic-1265-en/vufsw-t-statistic-1265-en.Rmd
@@ -92,6 +92,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/test statistic/t-statistic
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-t-test-1006-en/vufsw-t-test-1006-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-test-1006-en/vufsw-t-test-1006-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/t-test
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-testing-1125-en/vufsw-testing-1125-en.Rmd
+++ b/Inferential_Statistics/vufsw-testing-1125-en/vufsw-testing-1125-en.Rmd
@@ -93,6 +93,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/testing
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-two_proportions-1225-en/vufsw-two_proportions-1225-en.Rmd
+++ b/Inferential_Statistics/vufsw-two_proportions-1225-en/vufsw-two_proportions-1225-en.Rmd
@@ -45,6 +45,6 @@ exshuffle: TRUE
 exsection: inferential statistics/parametric techniques/z-test/two proportions
 exextra[Type]: test choice
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Inferential_Statistics/vufsw-twoway_anova-1374-en/vufsw-twoway_anova-1374-en.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1374-en/vufsw-twoway_anova-1374-en.Rmd
@@ -51,6 +51,6 @@ extol: 0.019999999999996
 exsection: inferential statistics/parametric techniques/anova/twoway anova
 exextra[Type]: interpreting output
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-type_I_error-1245-en/vufsw-type_I_error-1245-en.Rmd
+++ b/Inferential_Statistics/vufsw-type_I_error-1245-en/vufsw-type_I_error-1245-en.Rmd
@@ -57,6 +57,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/statistical errors/type I error
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-typeiierror-1173-en/vufsw-typeiierror-1173-en.Rmd
+++ b/Inferential_Statistics/vufsw-typeiierror-1173-en/vufsw-typeiierror-1173-en.Rmd
@@ -56,6 +56,6 @@ exshuffle: TRUE
 exsection: inferential statistics/nhst/statistical errors/type II error
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Inferential_Statistics/vufsw-width-1117-en/vufsw-width-1117-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1117-en/vufsw-width-1117-en.Rmd
@@ -38,6 +38,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-width-1159-en/vufsw-width-1159-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1159-en/vufsw-width-1159-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-width-1177-en/vufsw-width-1177-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1177-en/vufsw-width-1177-en.Rmd
@@ -58,6 +58,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-width-1181-en/vufsw-width-1181-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1181-en/vufsw-width-1181-en.Rmd
@@ -35,6 +35,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-width-1233-en/vufsw-width-1233-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1233-en/vufsw-width-1233-en.Rmd
@@ -77,6 +77,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-width-1271-en/vufsw-width-1271-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1271-en/vufsw-width-1271-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Inferential_Statistics/vufsw-width-1335-en/vufsw-width-1335-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1335-en/vufsw-width-1335-en.Rmd
@@ -54,6 +54,6 @@ exshuffle: TRUE
 exsection: inferential statistics/confidence intervals/width
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Probability/vufsw-conditional_probability-1234-en/vufsw-conditional_probability-1234-en.Rmd
+++ b/Probability/vufsw-conditional_probability-1234-en/vufsw-conditional_probability-1234-en.Rmd
@@ -74,6 +74,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/conditional probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Probability/vufsw-conditional_probability-1263-en/vufsw-conditional_probability-1263-en.Rmd
+++ b/Probability/vufsw-conditional_probability-1263-en/vufsw-conditional_probability-1263-en.Rmd
@@ -84,6 +84,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/conditional probability
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Probability/vufsw-elementary_probability-1269-en/vufsw-elementary_probability-1269-en.Rmd
+++ b/Probability/vufsw-elementary_probability-1269-en/vufsw-elementary_probability-1269-en.Rmd
@@ -48,6 +48,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Probability/vufsw-expected_value-1104-en/vufsw-expected_value-1104-en.Rmd
+++ b/Probability/vufsw-expected_value-1104-en/vufsw-expected_value-1104-en.Rmd
@@ -98,6 +98,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Probability/vufsw-expectedvalue-1098-en/vufsw-expectedvalue-1098-en.Rmd
+++ b/Probability/vufsw-expectedvalue-1098-en/vufsw-expectedvalue-1098-en.Rmd
@@ -52,6 +52,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Probability/vufsw-expectedvalue-1257-en/vufsw-expectedvalue-1257-en.Rmd
+++ b/Probability/vufsw-expectedvalue-1257-en/vufsw-expectedvalue-1257-en.Rmd
@@ -115,6 +115,6 @@ exshuffle: TRUE
 exsection: probability/elementary probability/random variables/expected value
 exextra[Type]: calculation
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Reliability/vufsw-cronbach's_alpha-1140/vufsw-cronbach's_alpha-1140.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1140/vufsw-cronbach's_alpha-1140.Rmd
@@ -80,6 +80,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Reliability/vufsw-cronbach's_alpha-1170-en/vufsw-cronbach's_alpha-1170-en.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1170-en/vufsw-cronbach's_alpha-1170-en.Rmd
@@ -106,6 +106,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Reliability/vufsw-cronbach's_alpha-1254-en/vufsw-cronbach's_alpha-1254-en.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1254-en/vufsw-cronbach's_alpha-1254-en.Rmd
@@ -42,6 +42,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach's_alpha-1337-en/vufsw-cronbach's_alpha-1337-en.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1337-en/vufsw-cronbach's_alpha-1337-en.Rmd
@@ -51,6 +51,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: interpreting output
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0070-en/vufsw-cronbach'salpha-0070-en.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0070-en/vufsw-cronbach'salpha-0070-en.Rmd
@@ -53,6 +53,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-0090-en/vufsw-cronbach'salpha-0090-en.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0090-en/vufsw-cronbach'salpha-0090-en.Rmd
@@ -55,6 +55,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: performing analysis
 exextra[Program]: calculator
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical thinking
 

--- a/Reliability/vufsw-cronbach'salpha-1122-en/vufsw-cronbach'salpha-1122-en.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-1122-en/vufsw-cronbach'salpha-1122-en.Rmd
@@ -50,6 +50,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Reliability/vufsw-cronbach'salpha-1248-en/vufsw-cronbach'salpha-1248-en.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-1248-en/vufsw-cronbach'salpha-1248-en.Rmd
@@ -63,6 +63,6 @@ exshuffle: TRUE
 exsection: reliability/analysis/cronbach's alpha
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical reasoning
 

--- a/Variable-type/vufsw-variabletype-1091-en/vufsw-variabletype-1091-en.Rmd
+++ b/Variable-type/vufsw-variabletype-1091-en/vufsw-variabletype-1091-en.Rmd
@@ -61,6 +61,6 @@ exshuffle: TRUE
 exsection: variable type
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/Variable-type/vufsw-variabletype-1101-en/vufsw-variabletype-1101-en.Rmd
+++ b/Variable-type/vufsw-variabletype-1101-en/vufsw-variabletype-1101-en.Rmd
@@ -40,6 +40,6 @@ exshuffle: TRUE
 exsection: variable type
 exextra[Type]: conceptual
 exextra[Program]: NA
-exextra[Language]: english
+exextra[Language]: English
 exextra[Level]: statistical literacy
 

--- a/scripts/fix_language_metadata.md
+++ b/scripts/fix_language_metadata.md
@@ -1,0 +1,12 @@
+There were typos in the language metadata value (for key `exextra[Language]`). The below steps use regex search and replace to fix these.
+
+* Ensure there is at least one space after metadata tag
+  * Search `exextra\[Language\]:([a-zA-Z]+)` replace with `exextra\[Language\]: $1`
+* Ensure there is not more than one space after metadata tag
+  * Search `exextra\[Language\]:  +([a-zA-Z]+)` replace with `exextra\[Language\]: $1`
+* Replace all English typos to English value by checking any metadata language value containing a "e" or "E"
+  * Search `exextra\[Language\]: [a-zA-Z]*[e|E][a-zA-Z]*` replace with `exextra\[Language\]: English`
+* Replace all Dutch typos to English value by checking any metadata language value containing a "d" or "D"
+  * Search `exextra\[Language\]: [a-zA-Z]*[d|D][a-zA-Z]*` replace with `exextra\[Language\]: Dutch`
+* Check for any occurrences which are not English or Dutch by searching: `exextra\[Language\]\: ((?!Dutch)(?!English))`
+  * Replace by hand or create a new regex.


### PR DESCRIPTION
This PR fixes all typos in the language metadata.
It also adds a "script" explaining the steps taken.