### PR TITLE
update files missing recursive tag

### DIFF
--- a/Assumptions/vufsw-assumptions-1004-en/vufsw-assumptions-1004-en.Rmd
+++ b/Assumptions/vufsw-assumptions-1004-en/vufsw-assumptions-1004-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("ppplot.png")
-include_supplement("residuals.png")
+include_supplement("ppplot.png", recursive = TRUE)
+include_supplement("residuals.png", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-assumptions-1009-en/vufsw-assumptions-1009-en.Rmd
+++ b/Assumptions/vufsw-assumptions-1009-en/vufsw-assumptions-1009-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("durbinwatson.png")
+include_supplement("durbinwatson.png", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-levene's_test-1381-nl/vufsw-levene's_test-1381-nl.Rmd
+++ b/Assumptions/vufsw-levene's_test-1381-nl/vufsw-levene's_test-1381-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602957985289.png")
-include_supplement("1602958004820.png")
-include_supplement("1602957955060.png")
-include_supplement("1602957967127.png")
+include_supplement("1602957985289.png", recursive = TRUE)
+include_supplement("1602958004820.png", recursive = TRUE)
+include_supplement("1602957955060.png", recursive = TRUE)
+include_supplement("1602957967127.png", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-levene'stest-0306-nl/vufsw-levene'stest-0306-nl.Rmd
+++ b/Assumptions/vufsw-levene'stest-0306-nl/vufsw-levene'stest-0306-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-levene'stest-0307-nl/vufsw-levene'stest-0307-nl.Rmd
+++ b/Assumptions/vufsw-levene'stest-0307-nl/vufsw-levene'stest-0307-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-levenestest-1288-nl/vufsw-levenestest-1288-nl.Rmd
+++ b/Assumptions/vufsw-levenestest-1288-nl/vufsw-levenestest-1288-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-ratio_of_variance-1377-nl/vufsw-ratio_of_variance-1377-nl.Rmd
+++ b/Assumptions/vufsw-ratio_of_variance-1377-nl/vufsw-ratio_of_variance-1377-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602950529966.png")
-include_supplement("1602950556931.png")
-include_supplement("1602950597019.png")
-include_supplement("1602950627758.png")
-include_supplement("1602950646258.png")
+include_supplement("1602950529966.png", recursive = TRUE)
+include_supplement("1602950556931.png", recursive = TRUE)
+include_supplement("1602950597019.png", recursive = TRUE)
+include_supplement("1602950627758.png", recursive = TRUE)
+include_supplement("1602950646258.png", recursive = TRUE)
 ```
 
 Question

--- a/Assumptions/vufsw-residualplot-0077-nl/vufsw-residualplot-0077-nl.Rmd
+++ b/Assumptions/vufsw-residualplot-0077-nl/vufsw-residualplot-0077-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2021-03-18__at__17.00.02.png")
+include_supplement("Screen__Shot__2021-03-18__at__17.00.02.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1292-nl/vufsw-correlation-1292-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1292-nl/vufsw-correlation-1292-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605610297110.png")
-include_supplement("1605610532984.png")
-include_supplement("1605610556019.png")
+include_supplement("1605610297110.png", recursive = TRUE)
+include_supplement("1605610532984.png", recursive = TRUE)
+include_supplement("1605610556019.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1294-nl/vufsw-correlation-1294-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1294-nl/vufsw-correlation-1294-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605616634166.png")
-include_supplement("1602856133971.png")
+include_supplement("1605616634166.png", recursive = TRUE)
+include_supplement("1602856133971.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1334-en/vufsw-correlation-1334-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1334-en/vufsw-correlation-1334-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631180947037.png")
+include_supplement("1631180947037.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1334-nl/vufsw-correlation-1334-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1334-nl/vufsw-correlation-1334-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631180947037.png")
+include_supplement("1631180947037.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1336-en/vufsw-correlation-1336-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1336-en/vufsw-correlation-1336-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631181911433.png")
+include_supplement("1631181911433.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1336-nl/vufsw-correlation-1336-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1336-nl/vufsw-correlation-1336-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631181911433.png")
+include_supplement("1631181911433.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1338-en/vufsw-correlation-1338-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1338-en/vufsw-correlation-1338-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631183026813.png")
+include_supplement("1631183026813.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1338-nl/vufsw-correlation-1338-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1338-nl/vufsw-correlation-1338-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631183026813.png")
+include_supplement("1631183026813.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1351-nl/vufsw-correlation-1351-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1351-nl/vufsw-correlation-1351-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602949639107.png")
+include_supplement("1602949639107.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-1352-nl/vufsw-correlation-1352-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-1352-nl/vufsw-correlation-1352-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602949639107.png")
-include_supplement("1602949826313.png")
-include_supplement("1602949868065.png")
-include_supplement("1602949886975.png")
-include_supplement("1602949911308.png")
+include_supplement("1602949639107.png", recursive = TRUE)
+include_supplement("1602949826313.png", recursive = TRUE)
+include_supplement("1602949868065.png", recursive = TRUE)
+include_supplement("1602949886975.png", recursive = TRUE)
+include_supplement("1602949911308.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-2000-en/vufsw-correlation-2000-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-2000-en/vufsw-correlation-2000-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1598532290271.png")
+include_supplement("1598532290271.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlation-2033-en/vufsw-correlation-2033-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlation-2033-en/vufsw-correlation-2033-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1598533294658.png")
+include_supplement("1598533294658.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlations-1030-en/vufsw-correlations-1030-en.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1030-en/vufsw-correlations-1030-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
+include_supplement("Capture.gif", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlations-1030-nl/vufsw-correlations-1030-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1030-nl/vufsw-correlations-1030-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
+include_supplement("Capture.gif", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlations-1295-nl/vufsw-correlations-1295-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1295-nl/vufsw-correlations-1295-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605614559401.png")
+include_supplement("1605614559401.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlations-1296-nl/vufsw-correlations-1296-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1296-nl/vufsw-correlations-1296-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605615806837.png")
-include_supplement("1606486140139.png")
-include_supplement("1602949868065.png")
-include_supplement("1602949886975.png")
-include_supplement("1602949911308.png")
+include_supplement("1605615806837.png", recursive = TRUE)
+include_supplement("1606486140139.png", recursive = TRUE)
+include_supplement("1602949868065.png", recursive = TRUE)
+include_supplement("1602949886975.png", recursive = TRUE)
+include_supplement("1602949911308.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlations-1297-nl/vufsw-correlations-1297-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1297-nl/vufsw-correlations-1297-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605617449406.png")
-include_supplement("1605617642249.png")
-include_supplement("1606486551882.png")
+include_supplement("1605617449406.png", recursive = TRUE)
+include_supplement("1605617642249.png", recursive = TRUE)
+include_supplement("1606486551882.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-correlations-1298-nl/vufsw-correlations-1298-nl.Rmd
+++ b/Descriptive-statistics/vufsw-correlations-1298-nl/vufsw-correlations-1298-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605617449406.png")
-include_supplement("1605617642249.png")
+include_supplement("1605617449406.png", recursive = TRUE)
+include_supplement("1605617642249.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-covariance-1333-en/vufsw-covariance-1333-en.Rmd
+++ b/Descriptive-statistics/vufsw-covariance-1333-en/vufsw-covariance-1333-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631180281739.png")
+include_supplement("1631180281739.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-covariance-1333-nl/vufsw-covariance-1333-nl.Rmd
+++ b/Descriptive-statistics/vufsw-covariance-1333-nl/vufsw-covariance-1333-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631180281739.png")
+include_supplement("1631180281739.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-covariance-1350-nl/vufsw-covariance-1350-nl.Rmd
+++ b/Descriptive-statistics/vufsw-covariance-1350-nl/vufsw-covariance-1350-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602856060527.png")
-include_supplement("1602856133971.png")
+include_supplement("1602856060527.png", recursive = TRUE)
+include_supplement("1602856133971.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-empiricalrule-0012-nl/vufsw-empiricalrule-0012-nl.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0012-nl/vufsw-empiricalrule-0012-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("image001578cc6dc.gif")
-include_supplement("image002578cc6dc.gif")
-include_supplement("image003578cc6dc.gif")
+include_supplement("image001578cc6dc.gif", recursive = TRUE)
+include_supplement("image002578cc6dc.gif", recursive = TRUE)
+include_supplement("image003578cc6dc.gif", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-empiricalrule-0027-nl/vufsw-empiricalrule-0027-nl.Rmd
+++ b/Descriptive-statistics/vufsw-empiricalrule-0027-nl/vufsw-empiricalrule-0027-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641291066836.png")
+include_supplement("1641291066836.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-graphs-0097-nl/vufsw-graphs-0097-nl.Rmd
+++ b/Descriptive-statistics/vufsw-graphs-0097-nl/vufsw-graphs-0097-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641901027144.png")
+include_supplement("1641901027144.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-histogram-0013-nl/vufsw-histogram-0013-nl.Rmd
+++ b/Descriptive-statistics/vufsw-histogram-0013-nl/vufsw-histogram-0013-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.20.09.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.20.09.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-interquartilerange-1083-en/vufsw-interquartilerange-1083-en.Rmd
+++ b/Descriptive-statistics/vufsw-interquartilerange-1083-en/vufsw-interquartilerange-1083-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1580470436317.png")
+include_supplement("1580470436317.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-measuresoflocation-0004-nl/vufsw-measuresoflocation-0004-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresoflocation-0004-nl/vufsw-measuresoflocation-0004-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641289742437.png")
+include_supplement("1641289742437.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-measuresoflocation-1076-en/vufsw-measuresoflocation-1076-en.Rmd
+++ b/Descriptive-statistics/vufsw-measuresoflocation-1076-en/vufsw-measuresoflocation-1076-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.20.09.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.20.09.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-measuresofspread-0001-nl/vufsw-measuresofspread-0001-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0001-nl/vufsw-measuresofspread-0001-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-24__at__01.47.52.png")
+include_supplement("Screen__Shot__2019-03-24__at__01.47.52.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-measuresofspread-0035-nl/vufsw-measuresofspread-0035-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0035-nl/vufsw-measuresofspread-0035-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-measuresofspread-0069-nl/vufsw-measuresofspread-0069-nl.Rmd
+++ b/Descriptive-statistics/vufsw-measuresofspread-0069-nl/vufsw-measuresofspread-0069-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-22__at__23.57.43.png")
-include_supplement("Screen__Shot__2019-03-22__at__23.56.23.png")
+include_supplement("Screen__Shot__2019-03-22__at__23.57.43.png", recursive = TRUE)
+include_supplement("Screen__Shot__2019-03-22__at__23.56.23.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-mode-0024-nl/vufsw-mode-0024-nl.Rmd
+++ b/Descriptive-statistics/vufsw-mode-0024-nl/vufsw-mode-0024-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Skewed__distribution.jpg")
+include_supplement("Skewed__distribution.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-standarddeviation-0049-nl/vufsw-standarddeviation-0049-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0049-nl/vufsw-standarddeviation-0049-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641291934883.png")
+include_supplement("1641291934883.png", recursive = TRUE)
 ```
 
 Question

--- a/Descriptive-statistics/vufsw-standarddeviation-0163-nl/vufsw-standarddeviation-0163-nl.Rmd
+++ b/Descriptive-statistics/vufsw-standarddeviation-0163-nl/vufsw-standarddeviation-0163-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643020221452.png")
+include_supplement("1643020221452.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-explained_variance-2110-en/vufsw-explained_variance-2110-en.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2110-en/vufsw-explained_variance-2110-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658143402810.png")
+include_supplement("1658143402810.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-explained_variance-2110-nl/vufsw-explained_variance-2110-nl.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2110-nl/vufsw-explained_variance-2110-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658143402810.png")
+include_supplement("1658143402810.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-explained_variance-2113-en/vufsw-explained_variance-2113-en.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2113-en/vufsw-explained_variance-2113-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658143402810.png")
+include_supplement("1658143402810.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-explained_variance-2113-nl/vufsw-explained_variance-2113-nl.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2113-nl/vufsw-explained_variance-2113-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658143402810.png")
+include_supplement("1658143402810.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-explained_variance-2114-en/vufsw-explained_variance-2114-en.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2114-en/vufsw-explained_variance-2114-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658145900098.png")
+include_supplement("1658145900098.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-explained_variance-2114-nl/vufsw-explained_variance-2114-nl.Rmd
+++ b/Factor-analysis/vufsw-explained_variance-2114-nl/vufsw-explained_variance-2114-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658145900098.png")
+include_supplement("1658145900098.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-factor_analysis-2109-nl/vufsw-factor_analysis-2109-nl.Rmd
+++ b/Factor-analysis/vufsw-factor_analysis-2109-nl/vufsw-factor_analysis-2109-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1658143402810.png")
+include_supplement("1658143402810.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-scree_plo-1299-nl/vufsw-scree_plo-1299-nl.Rmd
+++ b/Factor-analysis/vufsw-scree_plo-1299-nl/vufsw-scree_plo-1299-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605700807274.png")
-include_supplement("1605700826628.png")
+include_supplement("1605700807274.png", recursive = TRUE)
+include_supplement("1605700826628.png", recursive = TRUE)
 ```
 
 Question

--- a/Factor-analysis/vufsw-scree_plot-1290-en/vufsw-scree_plot-1290-en.Rmd
+++ b/Factor-analysis/vufsw-scree_plot-1290-en/vufsw-scree_plot-1290-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602958672291.png")
-include_supplement("1602958713146.png")
+include_supplement("1602958672291.png", recursive = TRUE)
+include_supplement("1602958713146.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-alternativehypothesis-0075-nl/vufsw-alternativehypothesis-0075-nl.Rmd
+++ b/Inferential_Statistics/vufsw-alternativehypothesis-0075-nl/vufsw-alternativehypothesis-0075-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-22__at__14.08.43.png")
+include_supplement("Screen__Shot__2020-04-22__at__14.08.43.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-alternativehypothesis-0223-nl/vufsw-alternativehypothesis-0223-nl.Rmd
+++ b/Inferential_Statistics/vufsw-alternativehypothesis-0223-nl/vufsw-alternativehypothesis-0223-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screenshot__2021-03-16__at__15.15.45.png")
+include_supplement("Screenshot__2021-03-16__at__15.15.45.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-0254-en/vufsw-ancova-0254-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0254-en/vufsw-ancova-0254-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615889347235.png")
+include_supplement("1615889347235.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-0254-nl/vufsw-ancova-0254-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-0254-nl/vufsw-ancova-0254-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615889347235.png")
+include_supplement("1615889347235.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2069-en/vufsw-ancova-2069-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2069-en/vufsw-ancova-2069-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2069-nl/vufsw-ancova-2069-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2069-nl/vufsw-ancova-2069-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2070-en/vufsw-ancova-2070-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2070-en/vufsw-ancova-2070-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2070-nl/vufsw-ancova-2070-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2070-nl/vufsw-ancova-2070-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2071-en/vufsw-ancova-2071-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2071-en/vufsw-ancova-2071-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2071-nl/vufsw-ancova-2071-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2071-nl/vufsw-ancova-2071-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2074-nl/vufsw-ancova-2074-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2074-nl/vufsw-ancova-2074-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2075-en/vufsw-ancova-2075-en.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2075-en/vufsw-ancova-2075-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2075-nl/vufsw-ancova-2075-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2075-nl/vufsw-ancova-2075-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2076-nl/vufsw-ancova-2076-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2076-nl/vufsw-ancova-2076-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ancova-2077-nl/vufsw-ancova-2077-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ancova-2077-nl/vufsw-ancova-2077-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-anova_f-test-1100-en/vufsw-anova_f-test-1100-en.Rmd
+++ b/Inferential_Statistics/vufsw-anova_f-test-1100-en/vufsw-anova_f-test-1100-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("anova__table.jpg")
+include_supplement("anova__table.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-anova_f-test-2068-nl/vufsw-anova_f-test-2068-nl.Rmd
+++ b/Inferential_Statistics/vufsw-anova_f-test-2068-nl/vufsw-anova_f-test-2068-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-anova_f-test-2073-nl/vufsw-anova_f-test-2073-nl.Rmd
+++ b/Inferential_Statistics/vufsw-anova_f-test-2073-nl/vufsw-anova_f-test-2073-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-anovaftest-0336-nl/vufsw-anovaftest-0336-nl.Rmd
+++ b/Inferential_Statistics/vufsw-anovaftest-0336-nl/vufsw-anovaftest-0336-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-anovaftest-1010-en/vufsw-anovaftest-1010-en.Rmd
+++ b/Inferential_Statistics/vufsw-anovaftest-1010-en/vufsw-anovaftest-1010-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12333.gif")
+include_supplement("Capture12333.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-bootstrap-0291-nl/vufsw-bootstrap-0291-nl.Rmd
+++ b/Inferential_Statistics/vufsw-bootstrap-0291-nl/vufsw-bootstrap-0291-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chi-squared_for_independence-1262-en/vufsw-chi-squared_for_independence-1262-en.Rmd
+++ b/Inferential_Statistics/vufsw-chi-squared_for_independence-1262-en/vufsw-chi-squared_for_independence-1262-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1547820971946.png")
+include_supplement("1547820971946.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquared-0005-nl/vufsw-chisquared-0005-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0005-nl/vufsw-chisquared-0005-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-05-01__at__02.20.06.png")
+include_supplement("Screen__Shot__2020-05-01__at__02.20.06.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquared-0064-nl/vufsw-chisquared-0064-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0064-nl/vufsw-chisquared-0064-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641292970572.png")
+include_supplement("1641292970572.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquared-0089-nl/vufsw-chisquared-0089-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0089-nl/vufsw-chisquared-0089-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641893103260.png")
+include_supplement("1641893103260.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquared-0092-nl/vufsw-chisquared-0092-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0092-nl/vufsw-chisquared-0092-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641898922841.png")
+include_supplement("1641898922841.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquared-0099-nl/vufsw-chisquared-0099-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0099-nl/vufsw-chisquared-0099-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641901241116.png")
+include_supplement("1641901241116.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquared-0112-nl/vufsw-chisquared-0112-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquared-0112-nl/vufsw-chisquared-0112-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643016226841.png")
+include_supplement("1643016226841.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0045-en/vufsw-chisquaredforindependence-0045-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0045-en/vufsw-chisquaredforindependence-0045-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641291849357.png")
+include_supplement("1641291849357.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0045-nl/vufsw-chisquaredforindependence-0045-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0045-nl/vufsw-chisquaredforindependence-0045-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641291849357.png")
+include_supplement("1641291849357.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0168-en/vufsw-chisquaredforindependence-0168-en.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0168-en/vufsw-chisquaredforindependence-0168-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643024901545.png")
+include_supplement("1643024901545.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-chisquaredforindependence-0168-nl/vufsw-chisquaredforindependence-0168-nl.Rmd
+++ b/Inferential_Statistics/vufsw-chisquaredforindependence-0168-nl/vufsw-chisquaredforindependence-0168-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643024901545.png")
+include_supplement("1643024901545.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1301-en/vufsw-coefficient_t-test-1301-en.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1301-en/vufsw-coefficient_t-test-1301-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1301-nl/vufsw-coefficient_t-test-1301-nl.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1301-nl/vufsw-coefficient_t-test-1301-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1353-en/vufsw-coefficient_t-test-1353-en.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1353-en/vufsw-coefficient_t-test-1353-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-coefficient_t-test-1353-nl/vufsw-coefficient_t-test-1353-nl.Rmd
+++ b/Inferential_Statistics/vufsw-coefficient_t-test-1353-nl/vufsw-coefficient_t-test-1353-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidence_interval-1310-nl/vufsw-confidence_interval-1310-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_interval-1310-nl/vufsw-confidence_interval-1310-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606293471454.png")
-include_supplement("1606293416277.png")
+include_supplement("1606293471454.png", recursive = TRUE)
+include_supplement("1606293416277.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidence_intervals-1339-en/vufsw-confidence_intervals-1339-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1339-en/vufsw-confidence_intervals-1339-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631281265839.png")
+include_supplement("1631281265839.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidence_intervals-1339-nl/vufsw-confidence_intervals-1339-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidence_intervals-1339-nl/vufsw-confidence_intervals-1339-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631281265839.png")
+include_supplement("1631281265839.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidenceinterval-0066-nl/vufsw-confidenceinterval-0066-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceinterval-0066-nl/vufsw-confidenceinterval-0066-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1616080027386.png")
+include_supplement("1616080027386.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidenceintervals-0188-nl/vufsw-confidenceintervals-0188-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0188-nl/vufsw-confidenceintervals-0188-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2021-02-27__at__22.35.49.png")
-include_supplement("Screen__Shot__2021-02-27__at__22.36.32.png")
-include_supplement("Screen__Shot__2021-02-27__at__22.32.01.png")
+include_supplement("Screen__Shot__2021-02-27__at__22.35.49.png", recursive = TRUE)
+include_supplement("Screen__Shot__2021-02-27__at__22.36.32.png", recursive = TRUE)
+include_supplement("Screen__Shot__2021-02-27__at__22.32.01.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidenceintervals-0228-nl/vufsw-confidenceintervals-0228-nl.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-0228-nl/vufsw-confidenceintervals-0228-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615967815188.png")
+include_supplement("1615967815188.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-confidenceintervals-1178-en/vufsw-confidenceintervals-1178-en.Rmd
+++ b/Inferential_Statistics/vufsw-confidenceintervals-1178-en/vufsw-confidenceintervals-1178-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-02-15__at__19.43.05.png")
+include_supplement("Screen__Shot__2020-02-15__at__19.43.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-correlation-1294-en/vufsw-correlation-1294-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1294-en/vufsw-correlation-1294-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605616634166.png")
-include_supplement("1602856133971.png")
+include_supplement("1605616634166.png", recursive = TRUE)
+include_supplement("1602856133971.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-correlation-1351-en/vufsw-correlation-1351-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1351-en/vufsw-correlation-1351-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602949639107.png")
+include_supplement("1602949639107.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-correlation-1352-en/vufsw-correlation-1352-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlation-1352-en/vufsw-correlation-1352-en.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602949639107.png")
-include_supplement("1602949826313.png")
-include_supplement("1602949868065.png")
-include_supplement("1602949886975.png")
-include_supplement("1602949911308.png")
+include_supplement("1602949639107.png", recursive = TRUE)
+include_supplement("1602949826313.png", recursive = TRUE)
+include_supplement("1602949868065.png", recursive = TRUE)
+include_supplement("1602949886975.png", recursive = TRUE)
+include_supplement("1602949911308.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-correlations-1296-en/vufsw-correlations-1296-en.Rmd
+++ b/Inferential_Statistics/vufsw-correlations-1296-en/vufsw-correlations-1296-en.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605615806837.png")
-include_supplement("1606486140139.png")
-include_supplement("1602949868065.png")
-include_supplement("1602949886975.png")
-include_supplement("1602949911308.png")
+include_supplement("1605615806837.png", recursive = TRUE)
+include_supplement("1606486140139.png", recursive = TRUE)
+include_supplement("1602949868065.png", recursive = TRUE)
+include_supplement("1602949886975.png", recursive = TRUE)
+include_supplement("1602949911308.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-criticalvalue-0080-nl/vufsw-criticalvalue-0080-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0080-nl/vufsw-criticalvalue-0080-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-24__at__14.56.10.png")
+include_supplement("Screen__Shot__2019-03-24__at__14.56.10.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-criticalvalue-0189-nl/vufsw-criticalvalue-0189-nl.Rmd
+++ b/Inferential_Statistics/vufsw-criticalvalue-0189-nl/vufsw-criticalvalue-0189-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2021-02-27__at__22.35.49.png")
-include_supplement("Screen__Shot__2021-02-27__at__22.36.32.png")
-include_supplement("Screen__Shot__2021-02-27__at__22.32.01.png")
+include_supplement("Screen__Shot__2021-02-27__at__22.35.49.png", recursive = TRUE)
+include_supplement("Screen__Shot__2021-02-27__at__22.36.32.png", recursive = TRUE)
+include_supplement("Screen__Shot__2021-02-27__at__22.32.01.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-crosstables-0002-en/vufsw-crosstables-0002-en.Rmd
+++ b/Inferential_Statistics/vufsw-crosstables-0002-en/vufsw-crosstables-0002-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.10.07.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.10.07.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-crosstables-0002-nl/vufsw-crosstables-0002-nl.Rmd
+++ b/Inferential_Statistics/vufsw-crosstables-0002-nl/vufsw-crosstables-0002-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.10.07.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.10.07.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-dummies-2060-nl/vufsw-dummies-2060-nl.Rmd
+++ b/Inferential_Statistics/vufsw-dummies-2060-nl/vufsw-dummies-2060-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.42.09.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.42.09.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-dummies-2065-nl/vufsw-dummies-2065-nl.Rmd
+++ b/Inferential_Statistics/vufsw-dummies-2065-nl/vufsw-dummies-2065-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.21.48.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.21.48.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-dummies-2066-nl/vufsw-dummies-2066-nl.Rmd
+++ b/Inferential_Statistics/vufsw-dummies-2066-nl/vufsw-dummies-2066-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.19.54.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.19.54.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0014-nl/vufsw-equation-0014-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0014-nl/vufsw-equation-0014-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("multiple__reg__formula__2.jpg")
+include_supplement("multiple__reg__formula__2.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0022-nl/vufsw-equation-0022-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0022-nl/vufsw-equation-0022-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-05-08__at__18.04.06.png")
+include_supplement("Screen__Shot__2019-05-08__at__18.04.06.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0040-nl/vufsw-equation-0040-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0040-nl/vufsw-equation-0040-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("multiple__reg__formula__2.jpg")
+include_supplement("multiple__reg__formula__2.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0041-en/vufsw-equation-0041-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0041-en/vufsw-equation-0041-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0041-nl/vufsw-equation-0041-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0041-nl/vufsw-equation-0041-nl.Rmd
@@ -4,7 +4,7 @@ output:
   html_document: default
 ---
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0157-en/vufsw-equation-0157-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0157-en/vufsw-equation-0157-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643019976688.png")
+include_supplement("1643019976688.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-0157-nl/vufsw-equation-0157-nl.Rmd
+++ b/Inferential_Statistics/vufsw-equation-0157-nl/vufsw-equation-0157-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643019976688.png")
+include_supplement("1643019976688.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-1095-en/vufsw-equation-1095-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1095-en/vufsw-equation-1095-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-08-10__at__22.19.05.png")
+include_supplement("Screen__Shot__2019-08-10__at__22.19.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-equation-1236-en/vufsw-equation-1236-en.Rmd
+++ b/Inferential_Statistics/vufsw-equation-1236-en/vufsw-equation-1236-en.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("multiple__reg__formula__1.jpg")
-include_supplement("multiple__reg__formula__2.jpg")
-include_supplement("multiple__reg__formula__3.jpg")
-include_supplement("multiple__reg__formula__4.jpg")
-include_supplement("multiple__reg__formula__2.jpg")
+include_supplement("multiple__reg__formula__1.jpg", recursive = TRUE)
+include_supplement("multiple__reg__formula__2.jpg", recursive = TRUE)
+include_supplement("multiple__reg__formula__3.jpg", recursive = TRUE)
+include_supplement("multiple__reg__formula__4.jpg", recursive = TRUE)
+include_supplement("multiple__reg__formula__2.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-expectedvalue-0118-en/vufsw-expectedvalue-0118-en.Rmd
+++ b/Inferential_Statistics/vufsw-expectedvalue-0118-en/vufsw-expectedvalue-0118-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643016977825.png")
+include_supplement("1643016977825.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-expectedvalue-0123-en/vufsw-expectedvalue-0123-en.Rmd
+++ b/Inferential_Statistics/vufsw-expectedvalue-0123-en/vufsw-expectedvalue-0123-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643017364978.png")
+include_supplement("1643017364978.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-explainedvariance-0170-en/vufsw-explainedvariance-0170-en.Rmd
+++ b/Inferential_Statistics/vufsw-explainedvariance-0170-en/vufsw-explainedvariance-0170-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-08-13__at__13.51.34.png")
+include_supplement("Screen__Shot__2019-08-13__at__13.51.34.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-explainedvariance-0170-nl/vufsw-explainedvariance-0170-nl.Rmd
+++ b/Inferential_Statistics/vufsw-explainedvariance-0170-nl/vufsw-explainedvariance-0170-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-08-13__at__13.51.34.png")
+include_supplement("Screen__Shot__2019-08-13__at__13.51.34.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1162-en/vufsw-independent_samples_means-1162-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1162-en/vufsw-independent_samples_means-1162-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("compare__means__t.png")
+include_supplement("compare__means__t.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1232-en/vufsw-independent_samples_means-1232-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1232-en/vufsw-independent_samples_means-1232-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
+include_supplement("Capture.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1249-en/vufsw-independent_samples_means-1249-en.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1249-en/vufsw-independent_samples_means-1249-en.Rmd
@@ -1,11 +1,11 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("image006578cc6dc.gif")
-include_supplement("image007578cc6dc.gif")
-include_supplement("image008578cc6dc.gif")
-include_supplement("image009578cc6dc.gif")
-include_supplement("image010578cc6dc.gif")
-include_supplement("image011578cc6dc.gif")
-include_supplement("1547814124015.png")
+include_supplement("image006578cc6dc.gif", recursive = TRUE)
+include_supplement("image007578cc6dc.gif", recursive = TRUE)
+include_supplement("image008578cc6dc.gif", recursive = TRUE)
+include_supplement("image009578cc6dc.gif", recursive = TRUE)
+include_supplement("image010578cc6dc.gif", recursive = TRUE)
+include_supplement("image011578cc6dc.gif", recursive = TRUE)
+include_supplement("1547814124015.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1379-nl/vufsw-independent_samples_means-1379-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1379-nl/vufsw-independent_samples_means-1379-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602957481292.png")
-include_supplement("1602957504685.png")
+include_supplement("1602957481292.png", recursive = TRUE)
+include_supplement("1602957504685.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1380-nl/vufsw-independent_samples_means-1380-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1380-nl/vufsw-independent_samples_means-1380-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602957481292.png")
-include_supplement("1602957504685.png")
+include_supplement("1602957481292.png", recursive = TRUE)
+include_supplement("1602957504685.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1382-nl/vufsw-independent_samples_means-1382-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1382-nl/vufsw-independent_samples_means-1382-nl.Rmd
@@ -1,12 +1,12 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602957985289.png")
-include_supplement("1602958004820.png")
-include_supplement("1602957955060.png")
-include_supplement("1602957967127.png")
-include_supplement("1602837664810.png")
-include_supplement("1602837678070.png")
-include_supplement("1602837695524.png")
-include_supplement("1602854063507.png")
+include_supplement("1602957985289.png", recursive = TRUE)
+include_supplement("1602958004820.png", recursive = TRUE)
+include_supplement("1602957955060.png", recursive = TRUE)
+include_supplement("1602957967127.png", recursive = TRUE)
+include_supplement("1602837664810.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
+include_supplement("1602837695524.png", recursive = TRUE)
+include_supplement("1602854063507.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independent_samples_means-1383-nl/vufsw-independent_samples_means-1383-nl.Rmd
+++ b/Inferential_Statistics/vufsw-independent_samples_means-1383-nl/vufsw-independent_samples_means-1383-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602957985289.png")
-include_supplement("1602958004820.png")
-include_supplement("1602957955060.png")
-include_supplement("1602957967127.png")
+include_supplement("1602957985289.png", recursive = TRUE)
+include_supplement("1602958004820.png", recursive = TRUE)
+include_supplement("1602957955060.png", recursive = TRUE)
+include_supplement("1602957967127.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-independentsamplesmeans-1174-en/vufsw-independentsamplesmeans-1174-en.Rmd
+++ b/Inferential_Statistics/vufsw-independentsamplesmeans-1174-en/vufsw-independentsamplesmeans-1174-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1644999332975.png")
+include_supplement("1644999332975.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-intercept-0095-nl/vufsw-intercept-0095-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-0095-nl/vufsw-intercept-0095-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.09.34.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.09.34.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-intercept-0224-nl/vufsw-intercept-0224-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-0224-nl/vufsw-intercept-0224-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screenshot__2021-03-16__at__15.15.45.png")
+include_supplement("Screenshot__2021-03-16__at__15.15.45.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-intercept-1355-nl/vufsw-intercept-1355-nl.Rmd
+++ b/Inferential_Statistics/vufsw-intercept-1355-nl/vufsw-intercept-1355-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-levene'stest-0307-en/vufsw-levene'stest-0307-en.Rmd
+++ b/Inferential_Statistics/vufsw-levene'stest-0307-en/vufsw-levene'stest-0307-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-0288-en/vufsw-manova-0288-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0288-en/vufsw-manova-0288-en.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture2.gif")
-include_supplement("Capture3.gif")
-include_supplement("Capture4.gif")
-include_supplement("Capture5.gif")
+include_supplement("Capture2.gif", recursive = TRUE)
+include_supplement("Capture3.gif", recursive = TRUE)
+include_supplement("Capture4.gif", recursive = TRUE)
+include_supplement("Capture5.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-0288-nl/vufsw-manova-0288-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0288-nl/vufsw-manova-0288-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture2.gif")
-include_supplement("Capture3.gif")
-include_supplement("Capture4.gif")
-include_supplement("Capture5.gif")
+include_supplement("Capture2.gif", recursive = TRUE)
+include_supplement("Capture3.gif", recursive = TRUE)
+include_supplement("Capture4.gif", recursive = TRUE)
+include_supplement("Capture5.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-0290-nl/vufsw-manova-0290-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-0290-nl/vufsw-manova-0290-nl.Rmd
@@ -1,12 +1,12 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture2.gif")
-include_supplement("Capture3.gif")
-include_supplement("Capture4.gif")
-include_supplement("Capture5.gif")
-include_supplement("Capture2.gif")
-include_supplement("Capture3.gif")
-include_supplement("Capture4.gif")
-include_supplement("Capture5.gif")
+include_supplement("Capture2.gif", recursive = TRUE)
+include_supplement("Capture3.gif", recursive = TRUE)
+include_supplement("Capture4.gif", recursive = TRUE)
+include_supplement("Capture5.gif", recursive = TRUE)
+include_supplement("Capture2.gif", recursive = TRUE)
+include_supplement("Capture3.gif", recursive = TRUE)
+include_supplement("Capture4.gif", recursive = TRUE)
+include_supplement("Capture5.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-1041-en/vufsw-manova-1041-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1041-en/vufsw-manova-1041-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("manova.png")
+include_supplement("manova.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-1041-nl/vufsw-manova-1041-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1041-nl/vufsw-manova-1041-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("manova.png")
+include_supplement("manova.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-1070-en/vufsw-manova-1070-en.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1070-en/vufsw-manova-1070-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
+include_supplement("Capture.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-manova-1070-nl/vufsw-manova-1070-nl.Rmd
+++ b/Inferential_Statistics/vufsw-manova-1070-nl/vufsw-manova-1070-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
+include_supplement("Capture.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0015-nl/vufsw-mediation-0015-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0015-nl/vufsw-mediation-0015-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-20__at__19.44.12.png")
+include_supplement("Screen__Shot__2020-04-20__at__19.44.12.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0127-nl/vufsw-mediation-0127-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0127-nl/vufsw-mediation-0127-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__21.47.15.png")
+include_supplement("Screen__Shot__2020-04-30__at__21.47.15.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0248-nl/vufsw-mediation-0248-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0248-nl/vufsw-mediation-0248-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1557484725807.png")
+include_supplement("1557484725807.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0292-en/vufsw-mediation-0292-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0292-en/vufsw-mediation-0292-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0292-nl/vufsw-mediation-0292-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0292-nl/vufsw-mediation-0292-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0293-nl/vufsw-mediation-0293-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0293-nl/vufsw-mediation-0293-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0294-nl/vufsw-mediation-0294-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0294-nl/vufsw-mediation-0294-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0295-nl/vufsw-mediation-0295-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0295-nl/vufsw-mediation-0295-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0296-nl/vufsw-mediation-0296-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0296-nl/vufsw-mediation-0296-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0297-nl/vufsw-mediation-0297-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0297-nl/vufsw-mediation-0297-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0298-nl/vufsw-mediation-0298-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0298-nl/vufsw-mediation-0298-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615993706039.png")
+include_supplement("1615993706039.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0299-nl/vufsw-mediation-0299-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0299-nl/vufsw-mediation-0299-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0300-nl/vufsw-mediation-0300-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0300-nl/vufsw-mediation-0300-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0301-nl/vufsw-mediation-0301-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0301-nl/vufsw-mediation-0301-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0302-nl/vufsw-mediation-0302-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0302-nl/vufsw-mediation-0302-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("mediation.png")
+include_supplement("mediation.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0303-nl/vufsw-mediation-0303-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0303-nl/vufsw-mediation-0303-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1552659287289.png")
+include_supplement("1552659287289.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0304-nl/vufsw-mediation-0304-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0304-nl/vufsw-mediation-0304-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12890.gif")
-include_supplement("Capture112891.gif")
+include_supplement("Capture12890.gif", recursive = TRUE)
+include_supplement("Capture112891.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-0305-nl/vufsw-mediation-0305-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-0305-nl/vufsw-mediation-0305-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12890.gif")
-include_supplement("Capture112891.gif")
+include_supplement("Capture12890.gif", recursive = TRUE)
+include_supplement("Capture112891.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1314-en/vufsw-mediation-1314-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1314-en/vufsw-mediation-1314-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606293471454.png")
-include_supplement("1606293416277.png")
+include_supplement("1606293471454.png", recursive = TRUE)
+include_supplement("1606293416277.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1315-en/vufsw-mediation-1315-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1315-en/vufsw-mediation-1315-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606293471454.png")
-include_supplement("1606293416277.png")
+include_supplement("1606293471454.png", recursive = TRUE)
+include_supplement("1606293416277.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1361-nl/vufsw-mediation-1361-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1361-nl/vufsw-mediation-1361-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1362-nl/vufsw-mediation-1362-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1362-nl/vufsw-mediation-1362-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1363-nl/vufsw-mediation-1363-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1363-nl/vufsw-mediation-1363-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1364-nl/vufsw-mediation-1364-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1364-nl/vufsw-mediation-1364-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1365-nl/vufsw-mediation-1365-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1365-nl/vufsw-mediation-1365-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1366-en/vufsw-mediation-1366-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1366-en/vufsw-mediation-1366-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1366-nl/vufsw-mediation-1366-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1366-nl/vufsw-mediation-1366-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1367-en/vufsw-mediation-1367-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1367-en/vufsw-mediation-1367-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1367-nl/vufsw-mediation-1367-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1367-nl/vufsw-mediation-1367-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1368-nl/vufsw-mediation-1368-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1368-nl/vufsw-mediation-1368-nl.Rmd
@@ -1,10 +1,10 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
-include_supplement("1602837664810.png")
-include_supplement("1602837678070.png")
-include_supplement("1602837695524.png")
-include_supplement("1602854063507.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
+include_supplement("1602837664810.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
+include_supplement("1602837695524.png", recursive = TRUE)
+include_supplement("1602854063507.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-1369-nl/vufsw-mediation-1369-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-1369-nl/vufsw-mediation-1369-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602951598702.png")
-include_supplement("1602951629778.png")
+include_supplement("1602951598702.png", recursive = TRUE)
+include_supplement("1602951629778.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2002-nl/vufsw-mediation-2002-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2002-nl/vufsw-mediation-2002-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817959608.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817959608.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2003-nl/vufsw-mediation-2003-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2003-nl/vufsw-mediation-2003-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817959608.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817959608.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2004-nl/vufsw-mediation-2004-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2004-nl/vufsw-mediation-2004-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817959608.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817959608.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2005-nl/vufsw-mediation-2005-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2005-nl/vufsw-mediation-2005-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817959608.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817959608.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2006-nl/vufsw-mediation-2006-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2006-nl/vufsw-mediation-2006-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2007-nl/vufsw-mediation-2007-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2007-nl/vufsw-mediation-2007-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2008-nl/vufsw-mediation-2008-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2008-nl/vufsw-mediation-2008-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2009-nl/vufsw-mediation-2009-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2009-nl/vufsw-mediation-2009-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817799761.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817809039.png")
-include_supplement("1657817812641.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817799761.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817809039.png", recursive = TRUE)
+include_supplement("1657817812641.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2010-nl/vufsw-mediation-2010-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2010-nl/vufsw-mediation-2010-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817601627.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817601627.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2012-nl/vufsw-mediation-2012-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2012-nl/vufsw-mediation-2012-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817601627.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817601627.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2013-nl/vufsw-mediation-2013-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2013-nl/vufsw-mediation-2013-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817601627.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817601627.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2014-nl/vufsw-mediation-2014-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2014-nl/vufsw-mediation-2014-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2015-nl/vufsw-mediation-2015-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2015-nl/vufsw-mediation-2015-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2016-nl/vufsw-mediation-2016-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2016-nl/vufsw-mediation-2016-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2017-nl/vufsw-mediation-2017-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2017-nl/vufsw-mediation-2017-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1657817289375.png")
-include_supplement("1657817294616.png")
-include_supplement("1657817306031.png")
-include_supplement("1657817315395.png")
-include_supplement("1657817324817.png")
+include_supplement("1657817289375.png", recursive = TRUE)
+include_supplement("1657817294616.png", recursive = TRUE)
+include_supplement("1657817306031.png", recursive = TRUE)
+include_supplement("1657817315395.png", recursive = TRUE)
+include_supplement("1657817324817.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2018-nl/vufsw-mediation-2018-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2018-nl/vufsw-mediation-2018-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2019-nl/vufsw-mediation-2019-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2019-nl/vufsw-mediation-2019-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2020-nl/vufsw-mediation-2020-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2020-nl/vufsw-mediation-2020-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2021-nl/vufsw-mediation-2021-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2021-nl/vufsw-mediation-2021-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2022-nl/vufsw-mediation-2022-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2022-nl/vufsw-mediation-2022-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2023-nl/vufsw-mediation-2023-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2023-nl/vufsw-mediation-2023-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2024-nl/vufsw-mediation-2024-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2024-nl/vufsw-mediation-2024-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2025-nl/vufsw-mediation-2025-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2025-nl/vufsw-mediation-2025-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2026-nl/vufsw-mediation-2026-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2026-nl/vufsw-mediation-2026-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2027-nl/vufsw-mediation-2027-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2027-nl/vufsw-mediation-2027-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2028-nl/vufsw-mediation-2028-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2028-nl/vufsw-mediation-2028-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2029-nl/vufsw-mediation-2029-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2029-nl/vufsw-mediation-2029-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2030-nl/vufsw-mediation-2030-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2030-nl/vufsw-mediation-2030-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-2031-nl/vufsw-mediation-2031-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-2031-nl/vufsw-mediation-2031-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png")
+include_supplement("Schermafbeelding__2019-01-30__om__13.05.49.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mediation-3034-en/vufsw-mediation-3034-en.Rmd
+++ b/Inferential_Statistics/vufsw-mediation-3034-en/vufsw-mediation-3034-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1598533153247.png")
+include_supplement("1598533153247.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1062-en/vufsw-mixed_design_anova-1062-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1062-en/vufsw-mixed_design_anova-1062-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture5.png")
+include_supplement("Capture5.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1062-nl/vufsw-mixed_design_anova-1062-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1062-nl/vufsw-mixed_design_anova-1062-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture5.png")
+include_supplement("Capture5.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1064-en/vufsw-mixed_design_anova-1064-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1064-en/vufsw-mixed_design_anova-1064-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12428.gif")
-include_supplement("effectsizecontrast.png")
+include_supplement("Capture12428.gif", recursive = TRUE)
+include_supplement("effectsizecontrast.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1064-nl/vufsw-mixed_design_anova-1064-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1064-nl/vufsw-mixed_design_anova-1064-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12428.gif")
-include_supplement("effectsizecontrast.png")
+include_supplement("Capture12428.gif", recursive = TRUE)
+include_supplement("effectsizecontrast.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1065-en/vufsw-mixed_design_anova-1065-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1065-en/vufsw-mixed_design_anova-1065-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12428.gif")
+include_supplement("Capture12428.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixed_design_anova-1065-nl/vufsw-mixed_design_anova-1065-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixed_design_anova-1065-nl/vufsw-mixed_design_anova-1065-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12428.gif")
+include_supplement("Capture12428.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0249-en/vufsw-mixeddesignanova-0249-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0249-en/vufsw-mixeddesignanova-0249-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture12428.gif")
+include_supplement("Capture12428.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0308-en/vufsw-mixeddesignanova-0308-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0308-en/vufsw-mixeddesignanova-0308-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0308-nl/vufsw-mixeddesignanova-0308-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0308-nl/vufsw-mixeddesignanova-0308-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0337-en/vufsw-mixeddesignanova-0337-en.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0337-en/vufsw-mixeddesignanova-0337-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-mixeddesignanova-0337-nl/vufsw-mixeddesignanova-0337-nl.Rmd
+++ b/Inferential_Statistics/vufsw-mixeddesignanova-0337-nl/vufsw-mixeddesignanova-0337-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture.gif")
-include_supplement("Capture1.gif")
+include_supplement("Capture.gif", recursive = TRUE)
+include_supplement("Capture1.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0016-nl/vufsw-moderation-0016-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0016-nl/vufsw-moderation-0016-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-05-02__at__17.31.19.png")
+include_supplement("Screen__Shot__2020-05-02__at__17.31.19.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0028-nl/vufsw-moderation-0028-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0028-nl/vufsw-moderation-0028-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0115-nl/vufsw-moderation-0115-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0115-nl/vufsw-moderation-0115-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__22.56.25.png")
+include_supplement("Screen__Shot__2020-04-30__at__22.56.25.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0169-nl/vufsw-moderation-0169-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0169-nl/vufsw-moderation-0169-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553526000257.png")
+include_supplement("1553526000257.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0222-nl/vufsw-moderation-0222-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0222-nl/vufsw-moderation-0222-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screenshot__2021-03-16__at__15.15.45.png")
+include_supplement("Screenshot__2021-03-16__at__15.15.45.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0230-nl/vufsw-moderation-0230-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0230-nl/vufsw-moderation-0230-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553776532675.png")
+include_supplement("1553776532675.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0244-nl/vufsw-moderation-0244-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0244-nl/vufsw-moderation-0244-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553784283127.png")
+include_supplement("1553784283127.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0311-en/vufsw-moderation-0311-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0311-en/vufsw-moderation-0311-en.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1637662117856.png")
-include_supplement("1637662133560.png")
-include_supplement("1637662152915.png")
+include_supplement("1637662117856.png", recursive = TRUE)
+include_supplement("1637662133560.png", recursive = TRUE)
+include_supplement("1637662152915.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0311-nl/vufsw-moderation-0311-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0311-nl/vufsw-moderation-0311-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1637662117856.png")
-include_supplement("1637662133560.png")
-include_supplement("1637662152915.png")
+include_supplement("1637662117856.png", recursive = TRUE)
+include_supplement("1637662133560.png", recursive = TRUE)
+include_supplement("1637662152915.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0312-en/vufsw-moderation-0312-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0312-en/vufsw-moderation-0312-en.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1637662117856.png")
-include_supplement("1637662133560.png")
-include_supplement("1637662152915.png")
+include_supplement("1637662117856.png", recursive = TRUE)
+include_supplement("1637662133560.png", recursive = TRUE)
+include_supplement("1637662152915.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-0312-nl/vufsw-moderation-0312-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-0312-nl/vufsw-moderation-0312-nl.Rmd
@@ -1,7 +1,7 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1637662117856.png")
-include_supplement("1637662133560.png")
-include_supplement("1637662152915.png")
+include_supplement("1637662117856.png", recursive = TRUE)
+include_supplement("1637662133560.png", recursive = TRUE)
+include_supplement("1637662152915.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1274-en/vufsw-moderation-1274-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1274-en/vufsw-moderation-1274-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("image003578f668a.jpg")
+include_supplement("image003578f668a.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1305-en/vufsw-moderation-1305-en.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1305-en/vufsw-moderation-1305-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1305-nl/vufsw-moderation-1305-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1305-nl/vufsw-moderation-1305-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1306-nl/vufsw-moderation-1306-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1306-nl/vufsw-moderation-1306-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
-include_supplement("1602953834719.png")
-include_supplement("1602953846278.png")
-include_supplement("1602953860292.png")
-include_supplement("1602953874532.png")
+include_supplement("1606660757397.png", recursive = TRUE)
+include_supplement("1602953834719.png", recursive = TRUE)
+include_supplement("1602953846278.png", recursive = TRUE)
+include_supplement("1602953860292.png", recursive = TRUE)
+include_supplement("1602953874532.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1348-nl/vufsw-moderation-1348-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1348-nl/vufsw-moderation-1348-nl.Rmd
@@ -1,11 +1,11 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602837169006.png")
-include_supplement("1602837181988.png")
-include_supplement("1602837197444.png")
-include_supplement("1602837695524.png")
-include_supplement("1602837678070.png")
-include_supplement("1602854063507.png")
-include_supplement("1602837664810.png")
+include_supplement("1602837169006.png", recursive = TRUE)
+include_supplement("1602837181988.png", recursive = TRUE)
+include_supplement("1602837197444.png", recursive = TRUE)
+include_supplement("1602837695524.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
+include_supplement("1602854063507.png", recursive = TRUE)
+include_supplement("1602837664810.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1356-nl/vufsw-moderation-1356-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1356-nl/vufsw-moderation-1356-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1357-nl/vufsw-moderation-1357-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1357-nl/vufsw-moderation-1357-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1358-nl/vufsw-moderation-1358-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1358-nl/vufsw-moderation-1358-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
-include_supplement("1602953834719.png")
-include_supplement("1602953846278.png")
-include_supplement("1602953860292.png")
-include_supplement("1602953874532.png")
+include_supplement("1602953152623.png", recursive = TRUE)
+include_supplement("1602953834719.png", recursive = TRUE)
+include_supplement("1602953846278.png", recursive = TRUE)
+include_supplement("1602953860292.png", recursive = TRUE)
+include_supplement("1602953874532.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-1359-nl/vufsw-moderation-1359-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-1359-nl/vufsw-moderation-1359-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2035-nl/vufsw-moderation-2035-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2035-nl/vufsw-moderation-2035-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2036-nl/vufsw-moderation-2036-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2036-nl/vufsw-moderation-2036-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2037-nl/vufsw-moderation-2037-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2037-nl/vufsw-moderation-2037-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2040-nl/vufsw-moderation-2040-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2040-nl/vufsw-moderation-2040-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2041-nl/vufsw-moderation-2041-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2041-nl/vufsw-moderation-2041-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2042-nl/vufsw-moderation-2042-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2042-nl/vufsw-moderation-2042-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2045-nl/vufsw-moderation-2045-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2045-nl/vufsw-moderation-2045-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2047-nl/vufsw-moderation-2047-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2047-nl/vufsw-moderation-2047-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2048-nl/vufsw-moderation-2048-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2048-nl/vufsw-moderation-2048-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2050-nl/vufsw-moderation-2050-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2050-nl/vufsw-moderation-2050-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2051-nl/vufsw-moderation-2051-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2051-nl/vufsw-moderation-2051-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2052-nl/vufsw-moderation-2052-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2052-nl/vufsw-moderation-2052-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2053-nl/vufsw-moderation-2053-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2053-nl/vufsw-moderation-2053-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2078-nl/vufsw-moderation-2078-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2078-nl/vufsw-moderation-2078-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2079-nl/vufsw-moderation-2079-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2079-nl/vufsw-moderation-2079-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2080-nl/vufsw-moderation-2080-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2080-nl/vufsw-moderation-2080-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2081-nl/vufsw-moderation-2081-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2081-nl/vufsw-moderation-2081-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.22.26.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2082-nl/vufsw-moderation-2082-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2082-nl/vufsw-moderation-2082-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.40.47.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.40.47.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2083-nl/vufsw-moderation-2083-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2083-nl/vufsw-moderation-2083-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.40.47.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.40.47.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2084-nl/vufsw-moderation-2084-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2084-nl/vufsw-moderation-2084-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.45.24.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.45.24.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2085-nl/vufsw-moderation-2085-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2085-nl/vufsw-moderation-2085-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__17.45.24.png")
+include_supplement("Schermafbeelding__2019-01-30__om__17.45.24.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2090-nl/vufsw-moderation-2090-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2090-nl/vufsw-moderation-2090-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2094-nl/vufsw-moderation-2094-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2094-nl/vufsw-moderation-2094-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2095-nl/vufsw-moderation-2095-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2095-nl/vufsw-moderation-2095-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2099-nl/vufsw-moderation-2099-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2099-nl/vufsw-moderation-2099-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2100-nl/vufsw-moderation-2100-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2100-nl/vufsw-moderation-2100-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2104-nl/vufsw-moderation-2104-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2104-nl/vufsw-moderation-2104-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-moderation-2105-nl/vufsw-moderation-2105-nl.Rmd
+++ b/Inferential_Statistics/vufsw-moderation-2105-nl/vufsw-moderation-2105-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1303-nl/vufsw-multiple_linear_regression-1303-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1303-nl/vufsw-multiple_linear_regression-1303-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1307-nl/vufsw-multiple_linear_regression-1307-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1307-nl/vufsw-multiple_linear_regression-1307-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-1354-nl/vufsw-multiple_linear_regression-1354-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-1354-nl/vufsw-multiple_linear_regression-1354-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602953152623.png")
+include_supplement("1602953152623.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2088-nl/vufsw-multiple_linear_regression-2088-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2088-nl/vufsw-multiple_linear_regression-2088-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2093-nl/vufsw-multiple_linear_regression-2093-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2093-nl/vufsw-multiple_linear_regression-2093-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2098-nl/vufsw-multiple_linear_regression-2098-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2098-nl/vufsw-multiple_linear_regression-2098-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiple_linear_regression-2103-nl/vufsw-multiple_linear_regression-2103-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiple_linear_regression-2103-nl/vufsw-multiple_linear_regression-2103-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiplelinearregression-0281-nl/vufsw-multiplelinearregression-0281-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-0281-nl/vufsw-multiplelinearregression-0281-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("capture.png")
+include_supplement("capture.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiplelinearregression-0328-nl/vufsw-multiplelinearregression-0328-nl.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-0328-nl/vufsw-multiplelinearregression-0328-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1620137896967.png")
-include_supplement("1620138066746.png")
+include_supplement("1620137896967.png", recursive = TRUE)
+include_supplement("1620138066746.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiplelinearregression-1002-en/vufsw-multiplelinearregression-1002-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-1002-en/vufsw-multiplelinearregression-1002-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture6.gif")
-include_supplement("Capture12.gif")
+include_supplement("Capture6.gif", recursive = TRUE)
+include_supplement("Capture12.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-multiplelinearregression-1003-en/vufsw-multiplelinearregression-1003-en.Rmd
+++ b/Inferential_Statistics/vufsw-multiplelinearregression-1003-en/vufsw-multiplelinearregression-1003-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture7.gif")
+include_supplement("Capture7.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-nhst-0162-nl/vufsw-nhst-0162-nl.Rmd
+++ b/Inferential_Statistics/vufsw-nhst-0162-nl/vufsw-nhst-0162-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553595822664.png")
+include_supplement("1553595822664.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-nullhypothesis-0227-nl/vufsw-nullhypothesis-0227-nl.Rmd
+++ b/Inferential_Statistics/vufsw-nullhypothesis-0227-nl/vufsw-nullhypothesis-0227-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615904596548.png")
+include_supplement("1615904596548.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-omega_squared-1372-nl/vufsw-omega_squared-1372-nl.Rmd
+++ b/Inferential_Statistics/vufsw-omega_squared-1372-nl/vufsw-omega_squared-1372-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602853914273.png")
-include_supplement("1602853939934.png")
-include_supplement("1602853960309.png")
-include_supplement("1602853971876.png")
-include_supplement("1601541221845.png")
+include_supplement("1602853914273.png", recursive = TRUE)
+include_supplement("1602853939934.png", recursive = TRUE)
+include_supplement("1602853960309.png", recursive = TRUE)
+include_supplement("1602853971876.png", recursive = TRUE)
+include_supplement("1601541221845.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onesidedhypothesis-0074-nl/vufsw-onesidedhypothesis-0074-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onesidedhypothesis-0074-nl/vufsw-onesidedhypothesis-0074-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-22__at__14.08.43.png")
+include_supplement("Screen__Shot__2020-04-22__at__14.08.43.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onesidedhypothesis-0120-nl/vufsw-onesidedhypothesis-0120-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onesidedhypothesis-0120-nl/vufsw-onesidedhypothesis-0120-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-22__at__14.08.43.png")
+include_supplement("Screen__Shot__2020-04-22__at__14.08.43.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-oneway_anova-1318-nl/vufsw-oneway_anova-1318-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1318-nl/vufsw-oneway_anova-1318-nl.Rmd
@@ -1,12 +1,12 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606661124383.png")
-include_supplement("1605701561156.png")
-include_supplement("1605701548380.png")
-include_supplement("1605701537573.png")
-include_supplement("1602837664810.png")
-include_supplement("1602837678070.png")
-include_supplement("1602854063507.png")
-include_supplement("1602837678070.png")
+include_supplement("1606661124383.png", recursive = TRUE)
+include_supplement("1605701561156.png", recursive = TRUE)
+include_supplement("1605701548380.png", recursive = TRUE)
+include_supplement("1605701537573.png", recursive = TRUE)
+include_supplement("1602837664810.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
+include_supplement("1602854063507.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-oneway_anova-1320-nl/vufsw-oneway_anova-1320-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1320-nl/vufsw-oneway_anova-1320-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606661124383.png")
-include_supplement("1605701561156.png")
-include_supplement("1605701548380.png")
-include_supplement("1605701537573.png")
-include_supplement("1601541221845.png")
+include_supplement("1606661124383.png", recursive = TRUE)
+include_supplement("1605701561156.png", recursive = TRUE)
+include_supplement("1605701548380.png", recursive = TRUE)
+include_supplement("1605701537573.png", recursive = TRUE)
+include_supplement("1601541221845.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-oneway_anova-1321-nl/vufsw-oneway_anova-1321-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1321-nl/vufsw-oneway_anova-1321-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606661124383.png")
-include_supplement("1605701561156.png")
-include_supplement("1605701548380.png")
-include_supplement("1605701537573.png")
+include_supplement("1606661124383.png", recursive = TRUE)
+include_supplement("1605701561156.png", recursive = TRUE)
+include_supplement("1605701548380.png", recursive = TRUE)
+include_supplement("1605701537573.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-oneway_anova-1370-nl/vufsw-oneway_anova-1370-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1370-nl/vufsw-oneway_anova-1370-nl.Rmd
@@ -1,12 +1,12 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602853914273.png")
-include_supplement("1602853939934.png")
-include_supplement("1602853960309.png")
-include_supplement("1602853971876.png")
-include_supplement("1602837664810.png")
-include_supplement("1602837678070.png")
-include_supplement("1602854063507.png")
-include_supplement("1602837678070.png")
+include_supplement("1602853914273.png", recursive = TRUE)
+include_supplement("1602853939934.png", recursive = TRUE)
+include_supplement("1602853960309.png", recursive = TRUE)
+include_supplement("1602853971876.png", recursive = TRUE)
+include_supplement("1602837664810.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
+include_supplement("1602854063507.png", recursive = TRUE)
+include_supplement("1602837678070.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-oneway_anova-1371-nl/vufsw-oneway_anova-1371-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1371-nl/vufsw-oneway_anova-1371-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602853914273.png")
-include_supplement("1602853939934.png")
-include_supplement("1602853960309.png")
-include_supplement("1602853971876.png")
+include_supplement("1602853914273.png", recursive = TRUE)
+include_supplement("1602853939934.png", recursive = TRUE)
+include_supplement("1602853960309.png", recursive = TRUE)
+include_supplement("1602853971876.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-oneway_anova-1373-nl/vufsw-oneway_anova-1373-nl.Rmd
+++ b/Inferential_Statistics/vufsw-oneway_anova-1373-nl/vufsw-oneway_anova-1373-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602853914273.png")
-include_supplement("1602853939934.png")
-include_supplement("1602853960309.png")
-include_supplement("1602853971876.png")
+include_supplement("1602853914273.png", recursive = TRUE)
+include_supplement("1602853939934.png", recursive = TRUE)
+include_supplement("1602853960309.png", recursive = TRUE)
+include_supplement("1602853971876.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-0255-nl/vufsw-onewayanova-0255-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0255-nl/vufsw-onewayanova-0255-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641299727441.png")
+include_supplement("1641299727441.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-0257-en/vufsw-onewayanova-0257-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0257-en/vufsw-onewayanova-0257-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641299727441.png")
+include_supplement("1641299727441.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-0258-nl/vufsw-onewayanova-0258-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0258-nl/vufsw-onewayanova-0258-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641295707354.png")
+include_supplement("1641295707354.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-0345-en/vufsw-onewayanova-0345-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0345-en/vufsw-onewayanova-0345-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1639491244371.png")
+include_supplement("1639491244371.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-0345-nl/vufsw-onewayanova-0345-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-0345-nl/vufsw-onewayanova-0345-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1639491244371.png")
+include_supplement("1639491244371.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-1247-en/vufsw-onewayanova-1247-en.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1247-en/vufsw-onewayanova-1247-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1644915328114.png")
+include_supplement("1644915328114.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-1285-nl/vufsw-onewayanova-1285-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1285-nl/vufsw-onewayanova-1285-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-1286-nl/vufsw-onewayanova-1286-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1286-nl/vufsw-onewayanova-1286-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled__1.png")
+include_supplement("Untitled__1.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-1287-nl/vufsw-onewayanova-1287-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1287-nl/vufsw-onewayanova-1287-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-onewayanova-1289-nl/vufsw-onewayanova-1289-nl.Rmd
+++ b/Inferential_Statistics/vufsw-onewayanova-1289-nl/vufsw-onewayanova-1289-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Untitled.png")
+include_supplement("Untitled.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pairedsamples-0141-nl/vufsw-pairedsamples-0141-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pairedsamples-0141-nl/vufsw-pairedsamples-0141-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643018916220.png")
+include_supplement("1643018916220.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pairedsamples-0146-nl/vufsw-pairedsamples-0146-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pairedsamples-0146-nl/vufsw-pairedsamples-0146-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643019321492.png")
+include_supplement("1643019321492.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pearson-1332-en/vufsw-pearson-1332-en.Rmd
+++ b/Inferential_Statistics/vufsw-pearson-1332-en/vufsw-pearson-1332-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631180281739.png")
+include_supplement("1631180281739.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pearson-1332-nl/vufsw-pearson-1332-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pearson-1332-nl/vufsw-pearson-1332-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631180281739.png")
+include_supplement("1631180281739.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pearson-1349-nl/vufsw-pearson-1349-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pearson-1349-nl/vufsw-pearson-1349-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602856060527.png")
-include_supplement("1602856133971.png")
+include_supplement("1602856060527.png", recursive = TRUE)
+include_supplement("1602856133971.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-0067-nl/vufsw-prediction-0067-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-0067-nl/vufsw-prediction-0067-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1639492084730.png")
+include_supplement("1639492084730.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2055-nl/vufsw-prediction-2055-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2055-nl/vufsw-prediction-2055-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2056-nl/vufsw-prediction-2056-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2056-nl/vufsw-prediction-2056-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2058-nl/vufsw-prediction-2058-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2058-nl/vufsw-prediction-2058-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2059-nl/vufsw-prediction-2059-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2059-nl/vufsw-prediction-2059-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2063-nl/vufsw-prediction-2063-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2063-nl/vufsw-prediction-2063-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2064-nl/vufsw-prediction-2064-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2064-nl/vufsw-prediction-2064-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2087-nl/vufsw-prediction-2087-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2087-nl/vufsw-prediction-2087-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2092-nl/vufsw-prediction-2092-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2092-nl/vufsw-prediction-2092-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-prediction-2096-nl/vufsw-prediction-2096-nl.Rmd
+++ b/Inferential_Statistics/vufsw-prediction-2096-nl/vufsw-prediction-2096-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pvalue-0073-nl/vufsw-pvalue-0073-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0073-nl/vufsw-pvalue-0073-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-24__at__14.56.10.png")
+include_supplement("Screen__Shot__2019-03-24__at__14.56.10.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pvalue-0102-nl/vufsw-pvalue-0102-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0102-nl/vufsw-pvalue-0102-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pvalue-0138-nl/vufsw-pvalue-0138-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0138-nl/vufsw-pvalue-0138-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pvalue-0194-nl/vufsw-pvalue-0194-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0194-nl/vufsw-pvalue-0194-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-02__at__18.57.08.png")
+include_supplement("Screen__Shot__2019-03-02__at__18.57.08.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-pvalue-0216-nl/vufsw-pvalue-0216-nl.Rmd
+++ b/Inferential_Statistics/vufsw-pvalue-0216-nl/vufsw-pvalue-0216-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-02__at__20.02.38.png")
+include_supplement("Screen__Shot__2019-03-02__at__20.02.38.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-r_squared_change-2057-nl/vufsw-r_squared_change-2057-nl.Rmd
+++ b/Inferential_Statistics/vufsw-r_squared_change-2057-nl/vufsw-r_squared_change-2057-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-r_squared_change-2061-nl/vufsw-r_squared_change-2061-nl.Rmd
+++ b/Inferential_Statistics/vufsw-r_squared_change-2061-nl/vufsw-r_squared_change-2061-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-ratio_of_variance-1330-nl/vufsw-ratio_of_variance-1330-nl.Rmd
+++ b/Inferential_Statistics/vufsw-ratio_of_variance-1330-nl/vufsw-ratio_of_variance-1330-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606310848601.png")
-include_supplement("1606310861407.png")
-include_supplement("1606310896679.png")
-include_supplement("1606310920191.png")
+include_supplement("1606310848601.png", recursive = TRUE)
+include_supplement("1606310861407.png", recursive = TRUE)
+include_supplement("1606310896679.png", recursive = TRUE)
+include_supplement("1606310920191.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-regression-0031-nl/vufsw-regression-0031-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-0031-nl/vufsw-regression-0031-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553595822664.png")
+include_supplement("1553595822664.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-regression-0072-nl/vufsw-regression-0072-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-0072-nl/vufsw-regression-0072-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-05-09__at__16.41.16.png")
+include_supplement("Screen__Shot__2019-05-09__at__16.41.16.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-regression-1115-nl/vufsw-regression-1115-nl.Rmd
+++ b/Inferential_Statistics/vufsw-regression-1115-nl/vufsw-regression-1115-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("image003.jpg")
+include_supplement("image003.jpg", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-residuals-0037-nl/vufsw-residuals-0037-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-0037-nl/vufsw-residuals-0037-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.36.04.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.36.04.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-residuals-0175-nl/vufsw-residuals-0175-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-0175-nl/vufsw-residuals-0175-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.36.04.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.36.04.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-residuals-1308-nl/vufsw-residuals-1308-nl.Rmd
+++ b/Inferential_Statistics/vufsw-residuals-1308-nl/vufsw-residuals-1308-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1605789338258.png")
-include_supplement("1605789327215.png")
+include_supplement("1605789338258.png", recursive = TRUE)
+include_supplement("1605789327215.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-rsquared-0087-nl/vufsw-rsquared-0087-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0087-nl/vufsw-rsquared-0087-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.09.34.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.09.34.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-rsquared-0121-nl/vufsw-rsquared-0121-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0121-nl/vufsw-rsquared-0121-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-rsquared-0226-nl/vufsw-rsquared-0226-nl.Rmd
+++ b/Inferential_Statistics/vufsw-rsquared-0226-nl/vufsw-rsquared-0226-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615904596548.png")
+include_supplement("1615904596548.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-rsquaredchange-1001-en/vufsw-rsquaredchange-1001-en.Rmd
+++ b/Inferential_Statistics/vufsw-rsquaredchange-1001-en/vufsw-rsquaredchange-1001-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture5.gif")
+include_supplement("Capture5.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-significancelevel-0156-nl/vufsw-significancelevel-0156-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0156-nl/vufsw-significancelevel-0156-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553595822664.png")
+include_supplement("1553595822664.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-significancelevel-0212-nl/vufsw-significancelevel-0212-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-0212-nl/vufsw-significancelevel-0212-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-02__at__20.02.38.png")
+include_supplement("Screen__Shot__2019-03-02__at__20.02.38.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-significancelevel-1103-nl/vufsw-significancelevel-1103-nl.Rmd
+++ b/Inferential_Statistics/vufsw-significancelevel-1103-nl/vufsw-significancelevel-1103-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1645520093057.png")
+include_supplement("1645520093057.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-simple_linear_regression-0219-nl/vufsw-simple_linear_regression-0219-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simple_linear_regression-0219-nl/vufsw-simple_linear_regression-0219-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1615903677730.png")
+include_supplement("1615903677730.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-simplelinearregression-0076-nl/vufsw-simplelinearregression-0076-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0076-nl/vufsw-simplelinearregression-0076-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screenshot__2021-02-13__at__12.28.08.png")
+include_supplement("Screenshot__2021-02-13__at__12.28.08.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-simplelinearregression-0166-nl/vufsw-simplelinearregression-0166-nl.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-0166-nl/vufsw-simplelinearregression-0166-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-08-10__at__22.19.05.png")
+include_supplement("Screen__Shot__2019-08-10__at__22.19.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-simplelinearregression-1005-en/vufsw-simplelinearregression-1005-en.Rmd
+++ b/Inferential_Statistics/vufsw-simplelinearregression-1005-en/vufsw-simplelinearregression-1005-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Capture2.gif")
+include_supplement("Capture2.gif", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-0107-nl/vufsw-slope-0107-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0107-nl/vufsw-slope-0107-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-0143-nl/vufsw-slope-0143-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0143-nl/vufsw-slope-0143-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.36.58.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-0151-nl/vufsw-slope-0151-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0151-nl/vufsw-slope-0151-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553595822664.png")
+include_supplement("1553595822664.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-0220-nl/vufsw-slope-0220-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-0220-nl/vufsw-slope-0220-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2021-03-25__at__16.09.25.png")
+include_supplement("Screen__Shot__2021-03-25__at__16.09.25.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-1272-en/vufsw-slope-1272-en.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1272-en/vufsw-slope-1272-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1553595822664.png")
+include_supplement("1553595822664.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-1302-nl/vufsw-slope-1302-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1302-nl/vufsw-slope-1302-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-1304-nl/vufsw-slope-1304-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1304-nl/vufsw-slope-1304-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606660757397.png")
+include_supplement("1606660757397.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-1309-nl/vufsw-slope-1309-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-1309-nl/vufsw-slope-1309-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606293471454.png")
-include_supplement("1606293416277.png")
+include_supplement("1606293471454.png", recursive = TRUE)
+include_supplement("1606293416277.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2038/vufsw-slope-2038.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2038/vufsw-slope-2038.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2039-nl/vufsw-slope-2039-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2039-nl/vufsw-slope-2039-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2043-nl/vufsw-slope-2043-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2043-nl/vufsw-slope-2043-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2044-nl/vufsw-slope-2044-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2044-nl/vufsw-slope-2044-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2046-nl/vufsw-slope-2046-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2046-nl/vufsw-slope-2046-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.50.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2049-nl/vufsw-slope-2049-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2049-nl/vufsw-slope-2049-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2054-nl/vufsw-slope-2054-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2054-nl/vufsw-slope-2054-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.57.21.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2062-nl/vufsw-slope-2062-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2062-nl/vufsw-slope-2062-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png")
+include_supplement("Schermafbeelding__2019-01-30__om__14.25.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2086-nl/vufsw-slope-2086-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2086-nl/vufsw-slope-2086-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2089-nl/vufsw-slope-2089-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2089-nl/vufsw-slope-2089-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2091-nl/vufsw-slope-2091-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2091-nl/vufsw-slope-2091-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2097-nl/vufsw-slope-2097-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2097-nl/vufsw-slope-2097-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2101-nl/vufsw-slope-2101-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2101-nl/vufsw-slope-2101-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-slope-2102-nl/vufsw-slope-2102-nl.Rmd
+++ b/Inferential_Statistics/vufsw-slope-2102-nl/vufsw-slope-2102-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png")
-include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png")
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.16.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-02-04__om__10.54.30.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-standarderroroftheestimate-0083-nl/vufsw-standarderroroftheestimate-0083-nl.Rmd
+++ b/Inferential_Statistics/vufsw-standarderroroftheestimate-0083-nl/vufsw-standarderroroftheestimate-0083-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2021-03-18__at__16.28.58.png")
+include_supplement("Screen__Shot__2021-03-18__at__16.28.58.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-standardizedcoefficient-0329-nl/vufsw-standardizedcoefficient-0329-nl.Rmd
+++ b/Inferential_Statistics/vufsw-standardizedcoefficient-0329-nl/vufsw-standardizedcoefficient-0329-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1620138066746.png")
+include_supplement("1620138066746.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-sum_of_squares-2067-nl/vufsw-sum_of_squares-2067-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sum_of_squares-2067-nl/vufsw-sum_of_squares-2067-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.20.50.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.21.31.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-sum_of_squares-2072-nl/vufsw-sum_of_squares-2072-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sum_of_squares-2072-nl/vufsw-sum_of_squares-2072-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png")
-include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png")
+include_supplement("Schermafbeelding__2019-01-30__om__19.34.46.png", recursive = TRUE)
+include_supplement("Schermafbeelding__2019-01-30__om__19.36.05.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-sumofsquares-0003-nl/vufsw-sumofsquares-0003-nl.Rmd
+++ b/Inferential_Statistics/vufsw-sumofsquares-0003-nl/vufsw-sumofsquares-0003-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1616082387828.png")
-include_supplement("1642088671658.png")
-include_supplement("1642088671658.png")
-include_supplement("1642088671658.png")
-include_supplement("1642088671658.png")
+include_supplement("1616082387828.png", recursive = TRUE)
+include_supplement("1642088671658.png", recursive = TRUE)
+include_supplement("1642088671658.png", recursive = TRUE)
+include_supplement("1642088671658.png", recursive = TRUE)
+include_supplement("1642088671658.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-t-statistic-1127-en/vufsw-t-statistic-1127-en.Rmd
+++ b/Inferential_Statistics/vufsw-t-statistic-1127-en/vufsw-t-statistic-1127-en.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-02-22__at__13.52.54.png")
-include_supplement("Screen__Shot__2020-02-22__at__13.53.59.png")
+include_supplement("Screen__Shot__2020-02-22__at__13.52.54.png", recursive = TRUE)
+include_supplement("Screen__Shot__2020-02-22__at__13.53.59.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-t-test-1323-nl/vufsw-t-test-1323-nl.Rmd
+++ b/Inferential_Statistics/vufsw-t-test-1323-nl/vufsw-t-test-1323-nl.Rmd
@@ -1,6 +1,6 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606303597973.png")
-include_supplement("1606656759675.png")
+include_supplement("1606303597973.png", recursive = TRUE)
+include_supplement("1606656759675.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-t-test-1326-nl/vufsw-t-test-1326-nl.Rmd
+++ b/Inferential_Statistics/vufsw-t-test-1326-nl/vufsw-t-test-1326-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606304344735.png")
-include_supplement("1606304365205.png")
-include_supplement("1606304444025.png")
-include_supplement("1606657035734.png")
+include_supplement("1606304344735.png", recursive = TRUE)
+include_supplement("1606304365205.png", recursive = TRUE)
+include_supplement("1606304444025.png", recursive = TRUE)
+include_supplement("1606657035734.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-tstatistic-0081-nl/vufsw-tstatistic-0081-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0081-nl/vufsw-tstatistic-0081-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-04-30__at__15.00.40.png")
+include_supplement("Screen__Shot__2020-04-30__at__15.00.40.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-tstatistic-0084-nl/vufsw-tstatistic-0084-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0084-nl/vufsw-tstatistic-0084-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-02__at__18.57.08.png")
+include_supplement("Screen__Shot__2019-03-02__at__18.57.08.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-tstatistic-0111-nl/vufsw-tstatistic-0111-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0111-nl/vufsw-tstatistic-0111-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643016030727.png")
+include_supplement("1643016030727.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-tstatistic-0190-nl/vufsw-tstatistic-0190-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0190-nl/vufsw-tstatistic-0190-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2021-02-27__at__23.36.42.png")
+include_supplement("Screen__Shot__2021-02-27__at__23.36.42.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-tstatistic-0225-nl/vufsw-tstatistic-0225-nl.Rmd
+++ b/Inferential_Statistics/vufsw-tstatistic-0225-nl/vufsw-tstatistic-0225-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643030975970.png")
+include_supplement("1643030975970.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1327-nl/vufsw-twoway_anova-1327-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1327-nl/vufsw-twoway_anova-1327-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606310848601.png")
-include_supplement("1606310861407.png")
-include_supplement("1606310896679.png")
-include_supplement("1606310920191.png")
+include_supplement("1606310848601.png", recursive = TRUE)
+include_supplement("1606310861407.png", recursive = TRUE)
+include_supplement("1606310896679.png", recursive = TRUE)
+include_supplement("1606310920191.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1328-nl/vufsw-twoway_anova-1328-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1328-nl/vufsw-twoway_anova-1328-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606310848601.png")
-include_supplement("1606310861407.png")
-include_supplement("1606310896679.png")
-include_supplement("1606310920191.png")
+include_supplement("1606310848601.png", recursive = TRUE)
+include_supplement("1606310861407.png", recursive = TRUE)
+include_supplement("1606310896679.png", recursive = TRUE)
+include_supplement("1606310920191.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1329-nl/vufsw-twoway_anova-1329-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1329-nl/vufsw-twoway_anova-1329-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606310848601.png")
-include_supplement("1606310861407.png")
-include_supplement("1606310896679.png")
-include_supplement("1606310920191.png")
+include_supplement("1606310848601.png", recursive = TRUE)
+include_supplement("1606310861407.png", recursive = TRUE)
+include_supplement("1606310896679.png", recursive = TRUE)
+include_supplement("1606310920191.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1331-nl/vufsw-twoway_anova-1331-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1331-nl/vufsw-twoway_anova-1331-nl.Rmd
@@ -1,8 +1,8 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1606310848601.png")
-include_supplement("1606310861407.png")
-include_supplement("1606310896679.png")
-include_supplement("1606310920191.png")
+include_supplement("1606310848601.png", recursive = TRUE)
+include_supplement("1606310861407.png", recursive = TRUE)
+include_supplement("1606310896679.png", recursive = TRUE)
+include_supplement("1606310920191.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1374-en/vufsw-twoway_anova-1374-en.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1374-en/vufsw-twoway_anova-1374-en.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602950529966.png")
-include_supplement("1602950556931.png")
-include_supplement("1602950597019.png")
-include_supplement("1602950627758.png")
-include_supplement("1602950646258.png")
+include_supplement("1602950529966.png", recursive = TRUE)
+include_supplement("1602950556931.png", recursive = TRUE)
+include_supplement("1602950597019.png", recursive = TRUE)
+include_supplement("1602950627758.png", recursive = TRUE)
+include_supplement("1602950646258.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1375-nl/vufsw-twoway_anova-1375-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1375-nl/vufsw-twoway_anova-1375-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602950529966.png")
-include_supplement("1602950556931.png")
-include_supplement("1602950597019.png")
-include_supplement("1602950627758.png")
-include_supplement("1602950646258.png")
+include_supplement("1602950529966.png", recursive = TRUE)
+include_supplement("1602950556931.png", recursive = TRUE)
+include_supplement("1602950597019.png", recursive = TRUE)
+include_supplement("1602950627758.png", recursive = TRUE)
+include_supplement("1602950646258.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1376-nl/vufsw-twoway_anova-1376-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1376-nl/vufsw-twoway_anova-1376-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602950529966.png")
-include_supplement("1602950556931.png")
-include_supplement("1602950597019.png")
-include_supplement("1602950627758.png")
-include_supplement("1602950646258.png")
+include_supplement("1602950529966.png", recursive = TRUE)
+include_supplement("1602950556931.png", recursive = TRUE)
+include_supplement("1602950597019.png", recursive = TRUE)
+include_supplement("1602950627758.png", recursive = TRUE)
+include_supplement("1602950646258.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-twoway_anova-1378-nl/vufsw-twoway_anova-1378-nl.Rmd
+++ b/Inferential_Statistics/vufsw-twoway_anova-1378-nl/vufsw-twoway_anova-1378-nl.Rmd
@@ -1,9 +1,9 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1602950529966.png")
-include_supplement("1602950556931.png")
-include_supplement("1602950597019.png")
-include_supplement("1602950627758.png")
-include_supplement("1602950646258.png")
+include_supplement("1602950529966.png", recursive = TRUE)
+include_supplement("1602950556931.png", recursive = TRUE)
+include_supplement("1602950597019.png", recursive = TRUE)
+include_supplement("1602950627758.png", recursive = TRUE)
+include_supplement("1602950646258.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-typeierror-0195-nl/vufsw-typeierror-0195-nl.Rmd
+++ b/Inferential_Statistics/vufsw-typeierror-0195-nl/vufsw-typeierror-0195-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-03-02__at__18.57.08.png")
+include_supplement("Screen__Shot__2019-03-02__at__18.57.08.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-width-1335-en/vufsw-width-1335-en.Rmd
+++ b/Inferential_Statistics/vufsw-width-1335-en/vufsw-width-1335-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631181429909.png")
+include_supplement("1631181429909.png", recursive = TRUE)
 ```
 
 Question

--- a/Inferential_Statistics/vufsw-width-1335-nl/vufsw-width-1335-nl.Rmd
+++ b/Inferential_Statistics/vufsw-width-1335-nl/vufsw-width-1335-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631181429909.png")
+include_supplement("1631181429909.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-expectedvalue-0118-nl/vufsw-expectedvalue-0118-nl.Rmd
+++ b/Probability/vufsw-expectedvalue-0118-nl/vufsw-expectedvalue-0118-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643016977825.png")
+include_supplement("1643016977825.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-expectedvalue-0123-nl/vufsw-expectedvalue-0123-nl.Rmd
+++ b/Probability/vufsw-expectedvalue-0123-nl/vufsw-expectedvalue-0123-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643017364978.png")
+include_supplement("1643017364978.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-expectedvalue-1098-en/vufsw-expectedvalue-1098-en.Rmd
+++ b/Probability/vufsw-expectedvalue-1098-en/vufsw-expectedvalue-1098-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1645087464335.png")
+include_supplement("1645087464335.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-probability-0050-nl/vufsw-probability-0050-nl.Rmd
+++ b/Probability/vufsw-probability-0050-nl/vufsw-probability-0050-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641292058186.png")
+include_supplement("1641292058186.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-probability-0052-nl/vufsw-probability-0052-nl.Rmd
+++ b/Probability/vufsw-probability-0052-nl/vufsw-probability-0052-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2019-02-21__at__00.41.54.png")
+include_supplement("Screen__Shot__2019-02-21__at__00.41.54.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-probability-0213-nl/vufsw-probability-0213-nl.Rmd
+++ b/Probability/vufsw-probability-0213-nl/vufsw-probability-0213-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1643026783957.png")
+include_supplement("1643026783957.png", recursive = TRUE)
 ```
 
 Question

--- a/Probability/vufsw-probability-2004-nl/vufsw-probability-2004-nl.Rmd
+++ b/Probability/vufsw-probability-2004-nl/vufsw-probability-2004-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1641291646198.png")
+include_supplement("1641291646198.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach's_alpha-1170-en/vufsw-cronbach's_alpha-1170-en.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1170-en/vufsw-cronbach's_alpha-1170-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screen__Shot__2020-02-08__at__14.51.59.png")
+include_supplement("Screen__Shot__2020-02-08__at__14.51.59.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach's_alpha-1337-en/vufsw-cronbach's_alpha-1337-en.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1337-en/vufsw-cronbach's_alpha-1337-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631181911433.png")
+include_supplement("1631181911433.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach's_alpha-1337-nl/vufsw-cronbach's_alpha-1337-nl.Rmd
+++ b/Reliability/vufsw-cronbach's_alpha-1337-nl/vufsw-cronbach's_alpha-1337-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1631181911433.png")
+include_supplement("1631181911433.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach'salpha-0025-nl/vufsw-cronbach'salpha-0025-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0025-nl/vufsw-cronbach'salpha-0025-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1648566577655.png")
+include_supplement("1648566577655.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach'salpha-0026-nl/vufsw-cronbach'salpha-0026-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0026-nl/vufsw-cronbach'salpha-0026-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1648566778339.png")
+include_supplement("1648566778339.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach'salpha-0090-en/vufsw-cronbach'salpha-0090-en.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0090-en/vufsw-cronbach'salpha-0090-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screenshot__2021-02-13__at__12.28.08.png")
+include_supplement("Screenshot__2021-02-13__at__12.28.08.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach'salpha-0090-nl/vufsw-cronbach'salpha-0090-nl.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-0090-nl/vufsw-cronbach'salpha-0090-nl.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("Screenshot__2021-02-13__at__12.28.08.png")
+include_supplement("Screenshot__2021-02-13__at__12.28.08.png", recursive = TRUE)
 ```
 
 Question

--- a/Reliability/vufsw-cronbach'salpha-1248-en/vufsw-cronbach'salpha-1248-en.Rmd
+++ b/Reliability/vufsw-cronbach'salpha-1248-en/vufsw-cronbach'salpha-1248-en.Rmd
@@ -1,5 +1,5 @@
 ```{r, echo = FALSE, results = "hide"}
-include_supplement("1645518804011.png")
+include_supplement("1645518804011.png", recursive = TRUE)
 ```
 
 Question

--- a/scripts/fix_include_supplement_recursive_property.md
+++ b/scripts/fix_include_supplement_recursive_property.md
@@ -1,0 +1,5 @@
+In some of the files the include_supplement was missing the `recursive = TRUE` property. Therefore, these supplements (e.g. images) were not included in the HTML as base64 encoded sources. To add the missing property, the following steps were taken: 
+
+* Find and replace all instances
+  * Find by regex: `include_supplement\("(.*)?" *)`
+  * Replace by `include_supplement(“$1”, recursive = TRUE)`


### PR DESCRIPTION
This fixes the issue where `include_supplement` does not include the `recursive = TRUE` tag.

This missing tag causes the files (mainly images) not to be base64 encoded which is required for compiling to HTML and the exam2Grasple script.

A Markdown file is added explaining how I did this search and replace with regex.